### PR TITLE
Download mesh script + handle non-triangular meshes

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -48,6 +48,12 @@ conda install -c conda-forge mesa-libgl-devel-cos7-x86_64 # may be necessary for
 pip install -r playground/requirements.txt
 ```
 
+3. Download a pack of interesting mesh assets:
+```bash
+chmod +x ./playground/download_assets.sh
+./playground/download_assets.sh
+```
+
 ## 🏃🏻 How to Run 🏃🏼‍♀️
 
 1. Train a 3DGRT scene, for example:
@@ -66,8 +72,9 @@ The playground supports loading `.pt` checkpoints, and exported `.ingp` and `.pl
 3. If desired, gather your own additional mesh assets (`.obj`, `.glb`, `.gltf` formats), and place them under `playground/assets/`.
 The playground will load them automatically as available *primitives* as soon as the app starts.
 Some interesting shapes are [available here](https://github.com/alecjacobson/common-3d-test-models/tree/master).
+A subset of those are downloaded with the `download_assets.sh` script.
 
-4. Have fun experimenting! 
+5. Have fun experimenting! 
 
 #### Additional args
 

--- a/playground/download_assets.sh
+++ b/playground/download_assets.sh
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 
 assets=(

--- a/playground/download_assets.sh
+++ b/playground/download_assets.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -13,17 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
 
 assets=(
-    "armadillo.obj"
-    "xyzrgb_dragon.obj"
-    "beast.obj"
-    "happy.obj"
-    "horse.obj"
-    "lucy.obj"
-    "nefertiti.obj"
-    "teapot.obj"
+    armadillo.obj
+    xyzrgb_dragon.obj
+    beast.obj
+    happy.obj
+    horse.obj
+    lucy.obj
+    nefertiti.obj
+    teapot.obj
 )
 
 # Source: https://github.com/alecjacobson/common-3d-test-models/blob/master/data

--- a/playground/download_assets.sh
+++ b/playground/download_assets.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+assets=(
+    "armadillo.obj"
+    "xyzrgb_dragon.obj"
+    "beast.obj"
+    "happy.obj"
+    "horse.obj"
+    "lucy.obj"
+    "nefertiti.obj"
+    "teapot.obj"
+)
+
+# Source: https://github.com/alecjacobson/common-3d-test-models/blob/master/data
+base_url="https://raw.githubusercontent.com/alecjacobson/common-3d-test-models/master/data"
+output_dir="./playground/assets"
+
+if command -v wget > /dev/null; then
+    downloader="wget"
+elif command -v curl > /dev/null; then
+    downloader="curl"
+else
+    echo "Error: Neither wget nor curl is installed. Please install one of them and re-run the script."
+    exit 1
+fi
+
+download_file() {
+    local file=$1
+    local url="$base_url/$file"
+    local output_path="$output_dir/$file"
+
+    if [[ -f "$output_path" ]]; then
+        echo "File '$file' already exists. Skipping download."
+    else
+        echo "Downloading '$file'..."
+
+        if [[ "$downloader" == "wget" ]]; then
+            wget -q --show-progress -O "$output_path" "$url"
+        else
+            curl -L -o "$output_path" "$url"
+        fi
+        if [[ $? -ne 0 ]]; then
+            echo "❌ Failed to download '$file'."
+            rm -f "$output_path"  # If an empty file was created, delete it
+        fi
+    fi
+}
+
+mkdir -p "$output_dir"
+echo "Downloading 3D mesh assets from '$base_url'"
+
+for asset in "${assets[@]}"; do
+    download_file "$asset"
+done
+
+echo "✅ Download complete. Files saved in '$output_dir'"

--- a/playground/utils/mesh_io.py
+++ b/playground/utils/mesh_io.py
@@ -134,10 +134,8 @@ def load_mesh(path: str, device):
     Supported formats: .obj, .gltf, .glb
     """
     format = Path(path).suffix
-    if format in ('.gltf', '.glb'):
-        mesh = kaolin.io.gltf.import_mesh(path)
-    elif format in ('.obj',):
-        mesh = kaolin.io.obj.import_mesh(path, with_normals=True)
+    if format in ('.obj', '.gltf', '.glb'):
+        mesh = kaolin.io.import_mesh(path, triangulate=True)
     else:
         raise ValueError(f'Cannot load mesh asset with unsupported format: {format}. '
                          f'Supported types: .obj, .glb, .gltf')


### PR DESCRIPTION
This PR adds:

1. A `./playground/download_assets.sh` script to download an initial pack of interesting mesh assets, used to create demos for the paper.

2. Changes `mesh_io.py` to use kaolin correctly so non-triangular meshes are not triangulated upon loading the asset.