### PR TITLE
Dynamic Materials + fix for UVs tensor

### DIFF
--- a/playground/include/playground/kernels/cuda/materials.cuh
+++ b/playground/include/playground/kernels/cuda/materials.cuh
@@ -30,74 +30,9 @@ extern "C"
     #endif
 }
 
-static __device__ __inline__ PBRMaterial get_material(const unsigned int matId)
+static __device__ __inline__ const PBRMaterial& get_material(const unsigned int matId)
 {
-    if (matId == 0)
-        return params.mat0;
-    else if (matId == 1)
-        return params.mat1;
-    else if (matId == 2)
-        return params.mat2;
-    else if (matId == 3)
-        return params.mat3;
-    else if (matId == 4)
-        return params.mat4;
-    else if (matId == 5)
-        return params.mat5;
-    else if (matId == 6)
-        return params.mat6;
-    else if (matId == 7)
-        return params.mat7;
-    else if (matId == 8)
-        return params.mat8;
-    else if (matId == 9)
-        return params.mat9;
-    else if (matId == 10)
-        return params.mat10;
-    else if (matId == 11)
-        return params.mat11;
-    else if (matId == 12)
-        return params.mat12;
-    else if (matId == 13)
-        return params.mat13;
-    else if (matId == 14)
-        return params.mat14;
-    else if (matId == 15)
-        return params.mat15;
-    else if (matId == 16)
-        return params.mat16;
-    else if (matId == 17)
-        return params.mat17;
-    else if (matId == 18)
-        return params.mat18;
-    else if (matId == 19)
-        return params.mat19;
-    else if (matId == 20)
-        return params.mat20;
-    else if (matId == 21)
-        return params.mat21;
-    else if (matId == 22)
-        return params.mat22;
-    else if (matId == 23)
-        return params.mat23;
-    else if (matId == 24)
-        return params.mat24;
-    else if (matId == 25)
-        return params.mat25;
-    else if (matId == 26)
-        return params.mat26;
-    else if (matId == 27)
-        return params.mat27;
-    else if (matId == 28)
-        return params.mat28;
-    else if (matId == 29)
-        return params.mat29;
-    else if (matId == 30)
-        return params.mat30;
-    else if (matId == 31)
-        return params.mat31;
-    else
-        return params.mat0; // default material, this should never happen unless some error occured
+    return params.materials[matId];
 }
 
 static __device__ __inline__ float3 get_diffuse_color(const float3 ray_d, float3 normal)

--- a/playground/include/playground/kernels/cuda/materials.cuh
+++ b/playground/include/playground/kernels/cuda/materials.cuh
@@ -38,16 +38,12 @@ static __device__ __inline__ const PBRMaterial& get_material(const unsigned int 
 static __device__ __inline__ float3 get_diffuse_color(const float3 ray_d, float3 normal)
 {
     const unsigned int triId = optixGetPrimitiveIndex();
-    const unsigned int v0_idx = params.triangles[triId][0];
-    const unsigned int v1_idx = params.triangles[triId][1];
-    const unsigned int v2_idx = params.triangles[triId][2];
-
     const unsigned int materialId = params.matID[triId][0];
     const auto material = get_material(materialId);
 
-    const float2 uv0 = make_float2(params.matUV[v0_idx][0], params.matUV[v0_idx][1]);
-    const float2 uv1 = make_float2(params.matUV[v1_idx][0], params.matUV[v1_idx][1]);
-    const float2 uv2 = make_float2(params.matUV[v2_idx][0], params.matUV[v2_idx][1]);
+    const float2 uv0 = make_float2(params.matUV[triId][0][0], params.matUV[triId][0][1]);
+    const float2 uv1 = make_float2(params.matUV[triId][1][0], params.matUV[triId][1][1]);
+    const float2 uv2 = make_float2(params.matUV[triId][2][0], params.matUV[triId][2][1]);
     const float2 barycentric = optixGetTriangleBarycentrics();
     float2 texCoords = (1 - barycentric.x - barycentric.y) * uv0 + barycentric.x * uv1 + barycentric.y * uv2;
 

--- a/playground/include/playground/pipelineParameters.h
+++ b/playground/include/playground/pipelineParameters.h
@@ -22,28 +22,29 @@
 #include <playground/pipelineDefinitions.h>
 #include <playground/cutexture.h>
 
-struct PBRMaterial
+struct alignas(16) PBRMaterial
 {
-    bool useDiffuseTexture;
-    float4 diffuseFactor;
-    cudaTextureObject_t diffuseTexture;
+    cudaTextureObject_t diffuseTexture;                     // 8 bytes -> offset 8
+    cudaTextureObject_t emissiveTexture;                    // 8 bytes -> offset 16
+    cudaTextureObject_t metallicRoughnessTexture;           // 8 bytes -> offset 24
+    cudaTextureObject_t normalTexture;                      // 8 bytes -> offset 32
 
-    bool useEmissiveTexture;
-    float3 emissiveFactor;
-    cudaTextureObject_t emissiveTexture;
+    float4 diffuseFactor;                                   // 16 bytes -> offset 48
+    float3 emissiveFactor;                                  // 12 bytes -> offset 60
+    float metallicFactor;                                   // 4 bytes  -> offset 64
+    float roughnessFactor;                                  // 4 bytes  -> offset 68
+    float transmissionFactor;                               // 4 bytes  -> offset 72
+    float ior;                                              // 4 bytes  -> offset 76
+    float alphaCutoff;                                      // 4 bytes  -> offset 80
+    unsigned int alphaMode;    // see GltfAlphaMode         // 4 bytes  -> offset 84
 
-    bool useMetallicRoughnessTexture;
-    float metallicFactor;
-    float roughnessFactor;
-    cudaTextureObject_t metallicRoughnessTexture;
+    bool useDiffuseTexture;                                 // 1 byte -> offset 85
+    bool useEmissiveTexture;                                // 1 byte -> offset 86
+    bool useMetallicRoughnessTexture;                       // 1 byte -> offset 87
+    bool useNormalTexture;                                  // 1 byte -> offset 88
 
-    bool useNormalTexture;
-    cudaTextureObject_t normalTexture;
-
-    unsigned int alphaMode;    // see GltfAlphaMode
-    float alphaCutoff;
-    float transmissionFactor;
-    float ior;
+    float2 pad0;                                            // 8 bytes -> offset 96
+    // --> mem 16 byte aligned
 };
 
 struct PlaygroundPipelineParameters: PipelineParameters
@@ -70,38 +71,8 @@ struct PlaygroundPipelineParameters: PipelineParameters
     // Materials
     PackedTensorAccessor32<float, 2> matUV;              // uv coordinates per vertex
     PackedTensorAccessor32<int32_t, 2> matID;            // id of material to use, per vertex
-    PBRMaterial mat0;                        // material 0
-    PBRMaterial mat1;                        // material 1
-    PBRMaterial mat2;                        // material 2
-    PBRMaterial mat3;                        // material 3
-    PBRMaterial mat4;                        // material 4
-    PBRMaterial mat5;                        // material 5
-    PBRMaterial mat6;                        // material 6
-    PBRMaterial mat7;                        // material 7
-    PBRMaterial mat8;                        // material 8
-    PBRMaterial mat9;                        // material 9
-    PBRMaterial mat10;                       // material 10
-    PBRMaterial mat11;                       // material 11
-    PBRMaterial mat12;                       // material 12
-    PBRMaterial mat13;                       // material 13
-    PBRMaterial mat14;                       // material 14
-    PBRMaterial mat15;                       // material 15
-    PBRMaterial mat16;                       // material 16
-    PBRMaterial mat17;                       // material 17
-    PBRMaterial mat18;                       // material 18
-    PBRMaterial mat19;                       // material 19
-    PBRMaterial mat20;                       // material 20
-    PBRMaterial mat21;                       // material 21
-    PBRMaterial mat22;                       // material 22
-    PBRMaterial mat23;                       // material 23
-    PBRMaterial mat24;                       // material 24
-    PBRMaterial mat25;                       // material 25
-    PBRMaterial mat26;                       // material 26
-    PBRMaterial mat27;                       // material 27
-    PBRMaterial mat28;                       // material 28
-    PBRMaterial mat29;                       // material 29
-    PBRMaterial mat30;                       // material 30
-    PBRMaterial mat31;                       // material 31
+    PBRMaterial* materials;                              // dynamic array of materials
+    unsigned int numMaterials;
 
     // Per triangle attributes
     PackedTensorAccessor32<int32_t, 2> primType;         // see PlaygroundPrimitiveTypes

--- a/playground/include/playground/pipelineParameters.h
+++ b/playground/include/playground/pipelineParameters.h
@@ -69,7 +69,7 @@ struct PlaygroundPipelineParameters: PipelineParameters
     PackedTensorAccessor32<float, 2> vTangents;    // vertex tangents
 
     // Materials
-    PackedTensorAccessor32<float, 2> matUV;              // uv coordinates per vertex
+    PackedTensorAccessor32<float, 3> matUV;              // [F,3,2]: triangular face X vertex X 2d uv
     PackedTensorAccessor32<int32_t, 2> matID;            // id of material to use, per vertex
     PBRMaterial* materials;                              // dynamic array of materials
     unsigned int numMaterials;

--- a/playground/playground.py
+++ b/playground/playground.py
@@ -294,7 +294,7 @@ class Primitives:
             vertex_normals=mesh.vertex_normals.float(),
             has_tangents=has_tangents.bool(),
             vertex_tangents=mesh.vertex_tangents.float(),
-            material_uv=mesh.uvs.float(),
+            material_uv=mesh.face_uvs.float(),
             material_id=mesh.material_assignments.unsqueeze(1).int(),
             primitive_type=primitive_type,
             primitive_type_tensor=prim_type_tensor.int(),
@@ -350,10 +350,12 @@ class Primitives:
                 v1 = [-MS, +MS, MZ]
                 v2 = [+MS, -MS, MZ]
                 v3 = [+MS, +MS, MZ]
+                faces = torch.tensor([[0, 1, 2], [2, 1, 3]])
+                vertex_uvs = torch.tensor([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
                 mesh = create_procedural_mesh(
                     vertices=torch.tensor([v0, v1, v2, v3]),
-                    faces=torch.tensor([[0, 1, 2], [2, 1, 3]]),
-                    uvs=torch.tensor([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]),
+                    faces=faces,
+                    face_uvs=vertex_uvs[faces].contiguous(), # (F, 3, 2)
                     device=device
                 )
             case _:
@@ -475,7 +477,12 @@ class Playground:
             rgb=None,
             opacity=None
         )
+        """ When this flag is toggled on, the state of the canvas have changed and it needs to be re-rendered
+        """
         self.is_force_canvas_dirty = False
+        """ When this flag is toggled on, the state of the materials have changed they need to be re-uploaded to device
+        """
+        self.is_materials_dirty = False
         self.gui_aux_fields = dict()
 
         self.is_running = True
@@ -556,6 +563,7 @@ class Playground:
             material_uv=self.primitives.stacked_fields.material_uv,
             material_id=self.primitives.stacked_fields.material_id,
             materials=sorted(self.primitives.registered_materials.values(), key=lambda mat: mat.material_id),
+            is_sync_materials=self.is_materials_dirty,
             refractive_index=self.primitives.stacked_fields.refractive_index_tensor[:, None],
             background_color=background_color,
             envmap=envmap,
@@ -876,6 +884,8 @@ class Playground:
         # Force dirty flag is on
         if self.is_force_canvas_dirty:
             return True
+        if self.is_materials_dirty:
+            return True
         if self.did_camera_change():
             return True
         if not self.has_cached_buffers():
@@ -1012,6 +1022,7 @@ class Playground:
 
         self.cache_last_state(view_params=view_params, outputs=outputs, window_size=(window_h, window_w))
         self.is_force_canvas_dirty = False
+        self.is_materials_dirty = False
         return outputs['rgb'], outputs['opacity']
 
     def update_data_on_device(self, buffer, tensor_array):
@@ -1519,6 +1530,7 @@ class Playground:
 
         if material_changed:
             self.is_force_canvas_dirty = True
+            self.is_materials_dirty = True
 
     def _draw_general_primitive_settings_widget(self):
         primitives_disabled = not self.primitives.enabled
@@ -1585,6 +1597,7 @@ class Playground:
             )
             self.primitives.rebuild_bvh_if_needed(True, True)
             self.is_force_canvas_dirty = True
+            self.is_materials_dirty = True
 
         psim.SameLine()
 
@@ -1617,6 +1630,7 @@ class Playground:
                 self._recompute_slice_planes()
                 self.primitives.rebuild_bvh_if_needed(force=True, rebuild=True)
                 self.is_force_canvas_dirty = True
+                self.is_materials_dirty = True
                 print(f'Scene loaded from {scene_path}')
         psim.PopItemWidth()
 
@@ -1730,9 +1744,6 @@ class Playground:
 
     def _draw_mirror_settings_widget(self, obj):
         pass
-        # settings_changed, self.mirrors.mirror_scatter = psim.SliderFloat(
-        #     "Scatter (Imperfectness)", self.mirrors.mirror_scatter, v_min=0.0, v_max=1e-2, power=1)
-        # self.is_force_canvas_dirty = self.is_force_canvas_dirty or settings_changed
 
     def _draw_single_trajectory_camera(self, i, eye, target, up):
         psim.PushItemWidth(200)

--- a/playground/src/hybridTracer.cpp
+++ b/playground/src/hybridTracer.cpp
@@ -31,6 +31,7 @@
 #include <playground/pipelineParameters.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAUtils.h>
+#include <memory>
 #include <cuda_runtime.h>
 #include <nvrtc.h>
 #include <algorithm>
@@ -200,74 +201,79 @@ void HybridOptixTracer::buildMeshBVH(
     CUDA_CHECK_LAST();
 }
 
-void HybridOptixTracer::setMaterialTextures(
+void HybridOptixTracer::syncMaterials(
     PlaygroundPipelineParameters& params,
-    unsigned int textureId,
-    CudaTexture2DFloat4Object& diffuseTexObject,
-    CudaTexture2DFloat4Object& emissiveTexObject,
-    CudaTexture2DFloat2Object& metallicRoughnessTexObject,
-    CudaTexture2DFloat4Object& normalTexObject,
-    const CPBRMaterial& cmat)
-{
-//    PBRMaterial* paramsMat = nullptr;
-//    switch (textureId)
-//    {
-//        case 0: paramsMat = &params.mat0; break;
-//        case 1: paramsMat = &params.mat1; break;
-//        case 2: paramsMat = &params.mat2; break;
-//        case 3: paramsMat = &params.mat3; break;
-//        case 4: paramsMat = &params.mat4; break;
-//        case 5: paramsMat = &params.mat5; break;
-//        case 6: paramsMat = &params.mat6; break;
-//        case 7: paramsMat = &params.mat7; break;
-//        case 8: paramsMat = &params.mat8; break;
-//        case 9: paramsMat = &params.mat9; break;
-//        case 10: paramsMat = &params.mat10; break;
-//        case 11: paramsMat = &params.mat11; break;
-//        case 12: paramsMat = &params.mat12; break;
-//        case 13: paramsMat = &params.mat13; break;
-//        case 14: paramsMat = &params.mat14; break;
-//        case 15: paramsMat = &params.mat15; break;
-//        case 16: paramsMat = &params.mat16; break;
-//        case 17: paramsMat = &params.mat17; break;
-//        case 18: paramsMat = &params.mat18; break;
-//        case 19: paramsMat = &params.mat19; break;
-//        case 20: paramsMat = &params.mat20; break;
-//        case 21: paramsMat = &params.mat21; break;
-//        case 22: paramsMat = &params.mat22; break;
-//        case 23: paramsMat = &params.mat23; break;
-//        case 24: paramsMat = &params.mat24; break;
-//        case 25: paramsMat = &params.mat25; break;
-//        case 26: paramsMat = &params.mat26; break;
-//        case 27: paramsMat = &params.mat27; break;
-//        case 28: paramsMat = &params.mat28; break;
-//        case 29: paramsMat = &params.mat29; break;
-//        case 30: paramsMat = &params.mat30; break;
-//        case 31: paramsMat = &params.mat31; break;
-//        default: break;
-//    }
-//
-//    if (paramsMat)
-//    {
-//        paramsMat->useDiffuseTexture = diffuseTexObject.isTexInitialized();
-//        paramsMat->diffuseTexture = diffuseTexObject.tex();
-//        paramsMat->useEmissiveTexture = emissiveTexObject.isTexInitialized();
-//        paramsMat->emissiveTexture = emissiveTexObject.tex();
-//        paramsMat->useMetallicRoughnessTexture = metallicRoughnessTexObject.isTexInitialized();
-//        paramsMat->metallicRoughnessTexture = metallicRoughnessTexObject.tex();
-//        paramsMat->useNormalTexture = normalTexObject.isTexInitialized();
-//        paramsMat->normalTexture = normalTexObject.tex();
-//        float* diffuseFactor = cmat.diffuseFactor.data_ptr<float>();
-//        paramsMat->diffuseFactor = make_float4(diffuseFactor[0], diffuseFactor[1], diffuseFactor[2], diffuseFactor[3]);
-//        float* emissiveFactor = cmat.emissiveFactor.data_ptr<float>();
-//        paramsMat->emissiveFactor = make_float3(emissiveFactor[0], emissiveFactor[1], emissiveFactor[2]);
-//        paramsMat->metallicFactor = cmat.metallicFactor;
-//        paramsMat->roughnessFactor = cmat.roughnessFactor;
-//        paramsMat->alphaMode = cmat.alphaMode;
-//        paramsMat->alphaCutoff = cmat.alphaCutoff;
-//        paramsMat->transmissionFactor = cmat.transmissionFactor;
-//        paramsMat->ior = cmat.ior;
-//    }
+    const std::vector<CPBRMaterial>& materials,
+    cudaStream_t cudaStream
+) {
+    size_t numMaterials = materials.size();
+
+    // Material Textures
+    std::vector<CudaTexture2DFloat4Object> cuDiffuseTexture(numMaterials);
+    std::vector<CudaTexture2DFloat4Object> cuEmissiveTexture(numMaterials);
+    std::vector<CudaTexture2DFloat2Object> cuMetallicRoughnessTexture(numMaterials);
+    std::vector<CudaTexture2DFloat4Object> cuNormalTexture(numMaterials);
+
+    _playgroundState->materials.resize(numMaterials);
+    _playgroundState->textures.resize(numMaterials);
+
+    for (int i = 0; i < numMaterials; ++i) {
+
+        auto& texture = _playgroundState->textures[i];
+
+        torch::Tensor texDiffuse = materials[i].diffuseMap;
+        int diffuseTexHeight = texDiffuse.size(0);
+        int diffuseTexWidth = texDiffuse.size(1);
+        texture.diffuse = std::make_shared<CudaTexture2DFloat4Object>();
+        if (diffuseTexHeight > 0 && diffuseTexWidth > 0) {
+            texture.diffuse->reset(texDiffuse.data_ptr<float>(), diffuseTexHeight, diffuseTexWidth);
+        }
+
+        torch::Tensor texEmissive = materials[i].emissiveMap;
+        int emissiveTexHeight = texEmissive.size(0);
+        int emissiveTexWidth = texEmissive.size(1);
+        texture.emissive = std::make_shared<CudaTexture2DFloat4Object>();
+        if (emissiveTexHeight > 0 && emissiveTexWidth > 0) {
+            texture.emissive->reset(texEmissive.data_ptr<float>(), emissiveTexHeight, emissiveTexWidth);
+        }
+
+        torch::Tensor texMetallicRoughness = materials[i].metallicRoughnessMap;
+        int metallicRoughnessTexHeight = texMetallicRoughness.size(0);
+        int metallicRoughnessTexWidth = texMetallicRoughness.size(1);
+        texture.metallicRoughness = std::make_shared<CudaTexture2DFloat2Object>();
+        if (metallicRoughnessTexHeight > 0 && metallicRoughnessTexWidth > 0) {
+            texture.metallicRoughness->reset(texMetallicRoughness.data_ptr<float>(),
+                                                  metallicRoughnessTexHeight, metallicRoughnessTexWidth);
+        }
+
+        torch::Tensor texNormal = materials[i].normalMap;
+        int normalTexHeight = texNormal.size(0);
+        int normalTexWidth = texNormal.size(1);
+        texture.normal = std::make_shared<CudaTexture2DFloat4Object>();
+        if (normalTexHeight > 0 && normalTexWidth > 0) {
+            texture.normal->reset(texNormal.data_ptr<float>(), normalTexHeight, normalTexWidth);
+        }
+
+        PBRMaterial& hostMat = _playgroundState->materials[i];
+        hostMat.useDiffuseTexture = texture.diffuse->isTexInitialized();
+        hostMat.diffuseTexture = texture.diffuse->tex();
+        hostMat.useEmissiveTexture = texture.emissive->isTexInitialized();
+        hostMat.emissiveTexture = texture.emissive->tex();
+        hostMat.useMetallicRoughnessTexture = texture.metallicRoughness->isTexInitialized();
+        hostMat.metallicRoughnessTexture = texture.metallicRoughness->tex();
+        hostMat.useNormalTexture = texture.normal->isTexInitialized();
+        hostMat.normalTexture = texture.normal->tex();
+        float* diffuseFactor = materials[i].diffuseFactor.data_ptr<float>();
+        hostMat.diffuseFactor = make_float4(diffuseFactor[0], diffuseFactor[1], diffuseFactor[2], diffuseFactor[3]);
+        float* emissiveFactor = materials[i].emissiveFactor.data_ptr<float>();
+        hostMat.emissiveFactor = make_float3(emissiveFactor[0], emissiveFactor[1], emissiveFactor[2]);
+        hostMat.metallicFactor = materials[i].metallicFactor;
+        hostMat.roughnessFactor = materials[i].roughnessFactor;
+        hostMat.alphaMode = materials[i].alphaMode;
+        hostMat.alphaCutoff = materials[i].alphaCutoff;
+        hostMat.transmissionFactor = materials[i].transmissionFactor;
+        hostMat.ior = materials[i].ior;
+    }
 }
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> HybridOptixTracer::traceHybrid(
@@ -289,6 +295,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
     torch::Tensor matUV,
     torch::Tensor matID,
     const std::vector<CPBRMaterial>& materials,
+    bool shouldSyncMaterials,
     torch::Tensor refractiveIndex,
     torch::Tensor backgroundColor,
     torch::Tensor envmap,
@@ -341,7 +348,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
     paramsHost.vTangents = packed_accessor32<float, 2>(vTangents);
     paramsHost.vHasTangents = packed_accessor32<bool, 2>(vHasTangents);
     paramsHost.primType = packed_accessor32<int32_t, 2>(primType);
-    paramsHost.matUV = packed_accessor32<float, 2>(matUV);
+    paramsHost.matUV = packed_accessor32<float, 3>(matUV);
     paramsHost.matID =  packed_accessor32<int32_t, 2>(matID);
     paramsHost.refractiveIndex = packed_accessor32<float, 2>(refractiveIndex);
     paramsHost.maxPBRBounces = maxPBRBounces;
@@ -363,91 +370,16 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
         paramsHost.envmap = cuEnvMap.tex();
     }
 
-    // Material Textures
-    size_t numMaterials = materials.size();
-    std::vector<CudaTexture2DFloat4Object> cuDiffuseTexture(numMaterials);
-    std::vector<CudaTexture2DFloat4Object> cuEmissiveTexture(numMaterials);
-    std::vector<CudaTexture2DFloat2Object> cuMetallicRoughnessTexture(numMaterials);
-    std::vector<CudaTexture2DFloat4Object> cuNormalTexture(numMaterials);
-    std::vector<PBRMaterial> launchMaterials(numMaterials);
-
-    for (int i = 0; i < numMaterials; ++i) {
-        torch::Tensor texDiffuse = materials[i].diffuseMap;
-        int diffuseTexHeight = texDiffuse.size(0);
-        int diffuseTexWidth = texDiffuse.size(1);
-        cuDiffuseTexture[i] = CudaTexture2DFloat4Object();
-        if (diffuseTexHeight > 0 && diffuseTexWidth > 0)
-        {
-            cuDiffuseTexture[i].reset(texDiffuse.data_ptr<float>(), diffuseTexHeight, diffuseTexWidth);
-        }
-
-        torch::Tensor texEmissive = materials[i].emissiveMap;
-        int emissiveTexHeight = texEmissive.size(0);
-        int emissiveTexWidth = texEmissive.size(1);
-        cuEmissiveTexture[i] = CudaTexture2DFloat4Object();
-        if (emissiveTexHeight > 0 && emissiveTexWidth > 0)
-        {
-            cuEmissiveTexture[i].reset(texEmissive.data_ptr<float>(), emissiveTexHeight, emissiveTexWidth);
-        }
-
-        torch::Tensor texMetallicRoughness = materials[i].metallicRoughnessMap;
-        int metallicRoughnessTexHeight = texMetallicRoughness.size(0);
-        int metallicRoughnessTexWidth = texMetallicRoughness.size(1);
-        cuMetallicRoughnessTexture[i] = CudaTexture2DFloat2Object();
-        if (metallicRoughnessTexHeight > 0 && metallicRoughnessTexWidth > 0)
-        {
-            cuMetallicRoughnessTexture[i].reset(texMetallicRoughness.data_ptr<float>(),
-                                                metallicRoughnessTexHeight, metallicRoughnessTexWidth);
-        }
-
-        torch::Tensor texNormal = materials[i].normalMap;
-        int normalTexHeight = texNormal.size(0);
-        int normalTexWidth = texNormal.size(1);
-        cuNormalTexture[i] = CudaTexture2DFloat4Object();
-        if (normalTexHeight > 0 && normalTexWidth > 0)
-        {
-            cuNormalTexture[i].reset(texNormal.data_ptr<float>(), normalTexHeight, normalTexWidth);
-        }
-
-//        setMaterialTextures(paramsHost, i,
-//                            cuDiffuseTexture[i], cuEmissiveTexture[i],
-//                            cuMetallicRoughnessTexture[i], cuNormalTexture[i],
-//                            materials[i]);
-        auto& diffuseTexObject = cuDiffuseTexture[i];
-        auto& emissiveTexObject = cuEmissiveTexture[i];
-        auto& metallicRoughnessTexObject = cuMetallicRoughnessTexture[i];
-        auto& normalTexObject = cuNormalTexture[i];
-        auto& cmat = materials[i];
-
-        launchMaterials[i].useDiffuseTexture = diffuseTexObject.isTexInitialized();
-        launchMaterials[i].diffuseTexture = diffuseTexObject.tex();
-        launchMaterials[i].useEmissiveTexture = emissiveTexObject.isTexInitialized();
-        launchMaterials[i].emissiveTexture = emissiveTexObject.tex();
-        launchMaterials[i].useMetallicRoughnessTexture = metallicRoughnessTexObject.isTexInitialized();
-        launchMaterials[i].metallicRoughnessTexture = metallicRoughnessTexObject.tex();
-        launchMaterials[i].useNormalTexture = normalTexObject.isTexInitialized();
-        launchMaterials[i].normalTexture = normalTexObject.tex();
-        float* diffuseFactor = cmat.diffuseFactor.data_ptr<float>();
-        launchMaterials[i].diffuseFactor = make_float4(diffuseFactor[0], diffuseFactor[1], diffuseFactor[2], diffuseFactor[3]);
-        float* emissiveFactor = cmat.emissiveFactor.data_ptr<float>();
-        launchMaterials[i].emissiveFactor = make_float3(emissiveFactor[0], emissiveFactor[1], emissiveFactor[2]);
-        launchMaterials[i].metallicFactor = cmat.metallicFactor;
-        launchMaterials[i].roughnessFactor = cmat.roughnessFactor;
-        launchMaterials[i].alphaMode = cmat.alphaMode;
-        launchMaterials[i].alphaCutoff = cmat.alphaCutoff;
-        launchMaterials[i].transmissionFactor = cmat.transmissionFactor;
-        launchMaterials[i].ior = cmat.ior;
-    }
-
     cudaStream_t cudaStream = at::cuda::getCurrentCUDAStream();
 
+    syncMaterials(paramsHost, materials, cudaStream);
+    unsigned int numMaterials = materials.size();
     CUDA_CHECK(cudaMallocAsync(
-       reinterpret_cast<void**>(&paramsHost.materials), sizeof(PBRMaterial) * numMaterials, cudaStream)
+        reinterpret_cast<void**>(&paramsHost.materials), sizeof(PBRMaterial) * numMaterials, cudaStream)
     );
     CUDA_CHECK(cudaMemcpyAsync(
-        reinterpret_cast<void*>(paramsHost.materials), launchMaterials.data(), sizeof(PBRMaterial) * numMaterials, cudaMemcpyHostToDevice, cudaStream)
+        reinterpret_cast<void*>(paramsHost.materials), _playgroundState->materials.data(), sizeof(PBRMaterial) * numMaterials, cudaMemcpyHostToDevice, cudaStream)
     );
-
     paramsHost.numMaterials = numMaterials;
 
     reallocatePlaygroundParamsDevice(sizeof(paramsHost), cudaStream);
@@ -462,10 +394,6 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
                         rayRad.size(1),
                         rayRad.size(0)
     ));
-
-//    if (paramsHost.materials != nullptr) {
-//        CUDA_CHECK(cudaFreeAsync(reinterpret_cast<void**>(&paramsHost.materials), cudaStream));
-//    }
 
     CUDA_CHECK_LAST();
 

--- a/playground/src/hybridTracer.cpp
+++ b/playground/src/hybridTracer.cpp
@@ -209,65 +209,65 @@ void HybridOptixTracer::setMaterialTextures(
     CudaTexture2DFloat4Object& normalTexObject,
     const CPBRMaterial& cmat)
 {
-    PBRMaterial* paramsMat = nullptr;
-    switch (textureId)
-    {
-        case 0: paramsMat = &params.mat0; break;
-        case 1: paramsMat = &params.mat1; break;
-        case 2: paramsMat = &params.mat2; break;
-        case 3: paramsMat = &params.mat3; break;
-        case 4: paramsMat = &params.mat4; break;
-        case 5: paramsMat = &params.mat5; break;
-        case 6: paramsMat = &params.mat6; break;
-        case 7: paramsMat = &params.mat7; break;
-        case 8: paramsMat = &params.mat8; break;
-        case 9: paramsMat = &params.mat9; break;
-        case 10: paramsMat = &params.mat10; break;
-        case 11: paramsMat = &params.mat11; break;
-        case 12: paramsMat = &params.mat12; break;
-        case 13: paramsMat = &params.mat13; break;
-        case 14: paramsMat = &params.mat14; break;
-        case 15: paramsMat = &params.mat15; break;
-        case 16: paramsMat = &params.mat16; break;
-        case 17: paramsMat = &params.mat17; break;
-        case 18: paramsMat = &params.mat18; break;
-        case 19: paramsMat = &params.mat19; break;
-        case 20: paramsMat = &params.mat20; break;
-        case 21: paramsMat = &params.mat21; break;
-        case 22: paramsMat = &params.mat22; break;
-        case 23: paramsMat = &params.mat23; break;
-        case 24: paramsMat = &params.mat24; break;
-        case 25: paramsMat = &params.mat25; break;
-        case 26: paramsMat = &params.mat26; break;
-        case 27: paramsMat = &params.mat27; break;
-        case 28: paramsMat = &params.mat28; break;
-        case 29: paramsMat = &params.mat29; break;
-        case 30: paramsMat = &params.mat30; break;
-        case 31: paramsMat = &params.mat31; break;
-        default: break;
-    }
-
-    if (paramsMat)
-    {
-        paramsMat->useDiffuseTexture = diffuseTexObject.isTexInitialized();
-        paramsMat->diffuseTexture = diffuseTexObject.tex();
-        paramsMat->useEmissiveTexture = emissiveTexObject.isTexInitialized();
-        paramsMat->emissiveTexture = emissiveTexObject.tex();
-        paramsMat->useMetallicRoughnessTexture = metallicRoughnessTexObject.isTexInitialized();
-        paramsMat->metallicRoughnessTexture = metallicRoughnessTexObject.tex();
-        paramsMat->useNormalTexture = normalTexObject.isTexInitialized();
-        paramsMat->normalTexture = normalTexObject.tex();
-        float* diffuseFactor = cmat.diffuseFactor.data_ptr<float>();
-        paramsMat->diffuseFactor = make_float4(diffuseFactor[0], diffuseFactor[1], diffuseFactor[2], diffuseFactor[3]);
-        float* emissiveFactor = cmat.emissiveFactor.data_ptr<float>();
-        paramsMat->emissiveFactor = make_float3(emissiveFactor[0], emissiveFactor[1], emissiveFactor[2]);
-        paramsMat->metallicFactor = cmat.metallicFactor;
-        paramsMat->roughnessFactor = cmat.roughnessFactor;
-        paramsMat->alphaMode = cmat.alphaMode;
-        paramsMat->alphaCutoff = cmat.alphaCutoff;
-        paramsMat->transmissionFactor = cmat.transmissionFactor;
-        paramsMat->ior = cmat.ior;
-    }
+//    PBRMaterial* paramsMat = nullptr;
+//    switch (textureId)
+//    {
+//        case 0: paramsMat = &params.mat0; break;
+//        case 1: paramsMat = &params.mat1; break;
+//        case 2: paramsMat = &params.mat2; break;
+//        case 3: paramsMat = &params.mat3; break;
+//        case 4: paramsMat = &params.mat4; break;
+//        case 5: paramsMat = &params.mat5; break;
+//        case 6: paramsMat = &params.mat6; break;
+//        case 7: paramsMat = &params.mat7; break;
+//        case 8: paramsMat = &params.mat8; break;
+//        case 9: paramsMat = &params.mat9; break;
+//        case 10: paramsMat = &params.mat10; break;
+//        case 11: paramsMat = &params.mat11; break;
+//        case 12: paramsMat = &params.mat12; break;
+//        case 13: paramsMat = &params.mat13; break;
+//        case 14: paramsMat = &params.mat14; break;
+//        case 15: paramsMat = &params.mat15; break;
+//        case 16: paramsMat = &params.mat16; break;
+//        case 17: paramsMat = &params.mat17; break;
+//        case 18: paramsMat = &params.mat18; break;
+//        case 19: paramsMat = &params.mat19; break;
+//        case 20: paramsMat = &params.mat20; break;
+//        case 21: paramsMat = &params.mat21; break;
+//        case 22: paramsMat = &params.mat22; break;
+//        case 23: paramsMat = &params.mat23; break;
+//        case 24: paramsMat = &params.mat24; break;
+//        case 25: paramsMat = &params.mat25; break;
+//        case 26: paramsMat = &params.mat26; break;
+//        case 27: paramsMat = &params.mat27; break;
+//        case 28: paramsMat = &params.mat28; break;
+//        case 29: paramsMat = &params.mat29; break;
+//        case 30: paramsMat = &params.mat30; break;
+//        case 31: paramsMat = &params.mat31; break;
+//        default: break;
+//    }
+//
+//    if (paramsMat)
+//    {
+//        paramsMat->useDiffuseTexture = diffuseTexObject.isTexInitialized();
+//        paramsMat->diffuseTexture = diffuseTexObject.tex();
+//        paramsMat->useEmissiveTexture = emissiveTexObject.isTexInitialized();
+//        paramsMat->emissiveTexture = emissiveTexObject.tex();
+//        paramsMat->useMetallicRoughnessTexture = metallicRoughnessTexObject.isTexInitialized();
+//        paramsMat->metallicRoughnessTexture = metallicRoughnessTexObject.tex();
+//        paramsMat->useNormalTexture = normalTexObject.isTexInitialized();
+//        paramsMat->normalTexture = normalTexObject.tex();
+//        float* diffuseFactor = cmat.diffuseFactor.data_ptr<float>();
+//        paramsMat->diffuseFactor = make_float4(diffuseFactor[0], diffuseFactor[1], diffuseFactor[2], diffuseFactor[3]);
+//        float* emissiveFactor = cmat.emissiveFactor.data_ptr<float>();
+//        paramsMat->emissiveFactor = make_float3(emissiveFactor[0], emissiveFactor[1], emissiveFactor[2]);
+//        paramsMat->metallicFactor = cmat.metallicFactor;
+//        paramsMat->roughnessFactor = cmat.roughnessFactor;
+//        paramsMat->alphaMode = cmat.alphaMode;
+//        paramsMat->alphaCutoff = cmat.alphaCutoff;
+//        paramsMat->transmissionFactor = cmat.transmissionFactor;
+//        paramsMat->ior = cmat.ior;
+//    }
 }
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> HybridOptixTracer::traceHybrid(
@@ -369,6 +369,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
     std::vector<CudaTexture2DFloat4Object> cuEmissiveTexture(numMaterials);
     std::vector<CudaTexture2DFloat2Object> cuMetallicRoughnessTexture(numMaterials);
     std::vector<CudaTexture2DFloat4Object> cuNormalTexture(numMaterials);
+    std::vector<PBRMaterial> launchMaterials(numMaterials);
 
     for (int i = 0; i < numMaterials; ++i) {
         torch::Tensor texDiffuse = materials[i].diffuseMap;
@@ -408,13 +409,46 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             cuNormalTexture[i].reset(texNormal.data_ptr<float>(), normalTexHeight, normalTexWidth);
         }
 
-        setMaterialTextures(paramsHost, i,
-                            cuDiffuseTexture[i], cuEmissiveTexture[i],
-                            cuMetallicRoughnessTexture[i], cuNormalTexture[i],
-                            materials[i]);
+//        setMaterialTextures(paramsHost, i,
+//                            cuDiffuseTexture[i], cuEmissiveTexture[i],
+//                            cuMetallicRoughnessTexture[i], cuNormalTexture[i],
+//                            materials[i]);
+        auto& diffuseTexObject = cuDiffuseTexture[i];
+        auto& emissiveTexObject = cuEmissiveTexture[i];
+        auto& metallicRoughnessTexObject = cuMetallicRoughnessTexture[i];
+        auto& normalTexObject = cuNormalTexture[i];
+        auto& cmat = materials[i];
+
+        launchMaterials[i].useDiffuseTexture = diffuseTexObject.isTexInitialized();
+        launchMaterials[i].diffuseTexture = diffuseTexObject.tex();
+        launchMaterials[i].useEmissiveTexture = emissiveTexObject.isTexInitialized();
+        launchMaterials[i].emissiveTexture = emissiveTexObject.tex();
+        launchMaterials[i].useMetallicRoughnessTexture = metallicRoughnessTexObject.isTexInitialized();
+        launchMaterials[i].metallicRoughnessTexture = metallicRoughnessTexObject.tex();
+        launchMaterials[i].useNormalTexture = normalTexObject.isTexInitialized();
+        launchMaterials[i].normalTexture = normalTexObject.tex();
+        float* diffuseFactor = cmat.diffuseFactor.data_ptr<float>();
+        launchMaterials[i].diffuseFactor = make_float4(diffuseFactor[0], diffuseFactor[1], diffuseFactor[2], diffuseFactor[3]);
+        float* emissiveFactor = cmat.emissiveFactor.data_ptr<float>();
+        launchMaterials[i].emissiveFactor = make_float3(emissiveFactor[0], emissiveFactor[1], emissiveFactor[2]);
+        launchMaterials[i].metallicFactor = cmat.metallicFactor;
+        launchMaterials[i].roughnessFactor = cmat.roughnessFactor;
+        launchMaterials[i].alphaMode = cmat.alphaMode;
+        launchMaterials[i].alphaCutoff = cmat.alphaCutoff;
+        launchMaterials[i].transmissionFactor = cmat.transmissionFactor;
+        launchMaterials[i].ior = cmat.ior;
     }
 
     cudaStream_t cudaStream = at::cuda::getCurrentCUDAStream();
+
+    CUDA_CHECK(cudaMallocAsync(
+       reinterpret_cast<void**>(&paramsHost.materials), sizeof(PBRMaterial) * numMaterials, cudaStream)
+    );
+    CUDA_CHECK(cudaMemcpyAsync(
+        reinterpret_cast<void*>(paramsHost.materials), launchMaterials.data(), sizeof(PBRMaterial) * numMaterials, cudaMemcpyHostToDevice, cudaStream)
+    );
+
+    paramsHost.numMaterials = numMaterials;
 
     reallocatePlaygroundParamsDevice(sizeof(paramsHost), cudaStream);
     CUDA_CHECK(cudaMemcpyAsync(
@@ -428,6 +462,10 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
                         rayRad.size(1),
                         rayRad.size(0)
     ));
+
+//    if (paramsHost.materials != nullptr) {
+//        CUDA_CHECK(cudaFreeAsync(reinterpret_cast<void**>(&paramsHost.materials), cudaStream));
+//    }
 
     CUDA_CHECK_LAST();
 

--- a/playground/tracer.py
+++ b/playground/tracer.py
@@ -200,6 +200,7 @@ class Tracer:
         material_uv=None,
         material_id=None,
         materials=None,
+        is_sync_materials=True,
         refractive_index=None,
         background_color=None,
         envmap=None,
@@ -212,7 +213,7 @@ class Tracer:
         if refractive_index is None:
             refractive_index = torch.ones_like(primitive_type, dtype=torch.float)
         if material_uv is None:
-            material_uv = torch.empty([0, 0], dtype=torch.float)
+            material_uv = torch.empty([0, 3, 2], dtype=torch.float)
         if material_id is None:
             material_id = torch.empty([0, 0], dtype=torch.int)
         if materials is None:
@@ -271,6 +272,7 @@ class Tracer:
                 material_uv,
                 material_id,
                 materials,
+                is_sync_materials,
                 refractive_index,
                 background_color,
                 envmap,


### PR DESCRIPTION
This PR:

* Removes the cap on static amount of materials in Optix / CUDA, we now add materials & textures to a dynamic array cached in the playground.
* Uploads materials to the GPU only if a new shape was loaded / materials were added. Avoid redundant texture syncs
* Includes a fix for UVs format to be updated to `(F, 3, 2` instead of `(V, 3)` (this is the correct way).