### PR TITLE
Alias Slang structs to avoid member names changes across versions

### DIFF
--- a/threedgut_tracer/include/3dgut/kernels/cuda/models/gaussianParticles.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/models/gaussianParticles.cuh
@@ -25,6 +25,13 @@ struct ParticleDensity {
     float padding;
 };
 
+struct ParticeFetchedDensity {
+    float3 position;
+    float3 scale;
+    float33 rotationT;
+    float density;
+};
+
 __forceinline__ __device__ void rotationMatrixTranspose(const float4& q, float33& ret) {
     const float r = q.x;
     const float x = q.y;

--- a/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutKBufferRenderer.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutKBufferRenderer.cuh
@@ -339,15 +339,15 @@ struct GUTKBufferRenderer : Params {
 
                 const PrefetchedRawParticleData particleData = prefetchedRawParticlesData[j];
                 if (particleData.idx == GUTParameters::InvalidParticleIdx) {
-                    i = tileNumBlocksToProcess;
+                    ray.kill();
                     break;
                 }
 
                 DensityRawParameters densityRawParametersGrad;
-                densityRawParametersGrad.density_0    = 0.0f;
-                densityRawParametersGrad.position_0   = make_float3(0.0f);
-                densityRawParametersGrad.quaternion_0 = make_float4(0.0f);
-                densityRawParametersGrad.scale_0      = make_float3(0.0f);
+                densityRawParametersGrad.density    = 0.0f;
+                densityRawParametersGrad.position   = make_float3(0.0f);
+                densityRawParametersGrad.quaternion = make_float4(0.0f);
+                densityRawParametersGrad.scale      = make_float3(0.0f);
 
                 TFeaturesVec featuresGrad = TFeaturesVec::zero();
 

--- a/threedgut_tracer/include/3dgut/threedgut.cuh
+++ b/threedgut_tracer/include/3dgut/threedgut.cuh
@@ -39,11 +39,7 @@ struct model_ExternalParams {
 
 #include <3dgut/kernels/cuda/models/shRadiativeGaussianParticles.cuh>
 
-using model_Particles = ShRadiativeGaussianVolumetricFeaturesParticles<gaussianParticle_Parameters_0,
-                                                                       shRadiativeParticle_Parameters_0,
-                                                                       model_InternalParams,
-                                                                       model_ExternalParams,
-                                                                       1>;
+using model_Particles = ShRadiativeGaussianVolumetricFeaturesParticles<model_InternalParams, model_ExternalParams, 1>;
 
 #include <3dgut/kernels/cuda/models/shGaussianModel.cuh>
 


### PR DESCRIPTION
fixes #6  : Alias Slang generated struct to force the naming of the member

- validation on bonsai :
![image](https://github.com/user-attachments/assets/249711cb-a121-4e0d-8955-49614d75a4e9)
