### PR TITLE
Fix projection sph backward (missing initialization of the active sph degree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To mitigate this limitation, we also propose 3DGUT, which enables support for di
 - [🔥 News](#-news)
 - [Contents](#contents)
 - [🔧 1 Dependencies and Installation](#-1-dependencies-and-installation)
+  - [Running with Docker](#running-with-docker)
 - [💻 2. Train 3DGRT or 3DGUT scenes](#-2-train-3dgrt-or-3dgut-scenes)
 - [🎥 3. Rendering from Checkpoints](#-3-rendering-from-checkpoints)
   - [To visualize training progress interactively](#to-visualize-training-progress-interactively)
@@ -181,7 +182,6 @@ Results for unsorted 3DGUT (Produced on RTX 5090):
 | FPS      | 269.5   | 362.3   | 336.7   | 276.2   | 333.3   | 310.6   | 383.1   | 333.3   | 326.8    | 325.8     |
 | PSNR     | 24.737  | 32.235  | 28.448  | 21.326  | 26.699  | 30.393  | 31.130  | 26.289  | 22.518   | 27.086    |
 
-_NOTE: A minor issue in computing SH gradients has been identified in the current implementation of 3DGUT. A temporary workaround has been applied in PR [#23](https://github.com/nv-tlabs/3dgrut/pull/23). We are actively investigating the underlying cause and will implement a permanent solution shortly._
 
 #### Scannet++ Dataset
 

--- a/threedgut_tracer/include/3dgut/kernels/cuda/models/shRadiativeGaussianParticles.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/models/shRadiativeGaussianParticles.cuh
@@ -273,12 +273,12 @@ struct ShRadiativeGaussianVolumetricFeaturesParticles : Params, public ExtParams
                                     *reinterpret_cast<const float3*>(&incidentDirection));
     }
 
+    template <bool Atomic = false>
     __forceinline__ __device__ void featuresBwdCustomToBuffer(uint32_t particleIdx,
                                                               const TFeaturesVec& features,
                                                               const TFeaturesVec& featuresGrad,
                                                               const tcnn::vec3& incidentDirection) const {
-
-        threedgut::radianceFromSpHBwd(m_featureActiveShDegree,
+        threedgut::radianceFromSpHBwd<Atomic>(m_featureActiveShDegree,
                                       *reinterpret_cast<const float3*>(&incidentDirection),
                                       *reinterpret_cast<const float3*>(&featuresGrad),
                                       reinterpret_cast<float3*>(&m_featureRawParameters.gradPtr[particleIdx * ExtParams::RadianceMaxNumSphCoefficients]),

--- a/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutProjector.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutProjector.cuh
@@ -416,14 +416,11 @@ struct GUTProjector : Params, UTParams {
 
         particles.initializeFeatures(parameters);
         particles.initializeFeaturesGradient(parametersGradient);
-        particles.featuresBwdToBuffer<true>(particleIdx,
-                                            reinterpret_cast<const TFeaturesVec*>(particlesPrecomputedFeaturesGradPtr)[particleIdx],
-                                            incidentDirection);
-        // FIXME : the custom backward induce a loss in accuracy
-        // particles.featuresBwdCustomToBuffer(particleIdx,
-        //                                     reinterpret_cast<const TFeaturesVec*>(particlesPrecomputedFeaturesPtr)[particleIdx],
-        //                                     reinterpret_cast<const TFeaturesVec*>(particlesPrecomputedFeaturesGradPtr)[particleIdx],
-        //                                     incidentDirection);
+        particles.featuresBwdCustomToBuffer<false>(
+            particleIdx,
+            reinterpret_cast<const TFeaturesVec*>(particlesPrecomputedFeaturesPtr)[particleIdx],
+            reinterpret_cast<const TFeaturesVec*>(particlesPrecomputedFeaturesGradPtr)[particleIdx],
+            incidentDirection);
         particles.initializeDensityGradient(parametersGradient);
         particles.template densityIncidentDirectionBwdToBuffer<true>(particleIdx, sensorWorldPosition);
     }

--- a/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutProjector.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutProjector.cuh
@@ -424,7 +424,6 @@ struct GUTProjector : Params, UTParams {
         //                                     reinterpret_cast<const TFeaturesVec*>(particlesPrecomputedFeaturesPtr)[particleIdx],
         //                                     reinterpret_cast<const TFeaturesVec*>(particlesPrecomputedFeaturesGradPtr)[particleIdx],
         //                                     incidentDirection);
-
         particles.initializeDensityGradient(parametersGradient);
         particles.template densityIncidentDirectionBwdToBuffer<true>(particleIdx, sensorWorldPosition);
     }


### PR DESCRIPTION
Validation on bonsai :
![image](https://github.com/user-attachments/assets/bc9f6ee6-442f-4759-bdb2-03312da4e6d1)
