### PR TITLE
optimize trainer + colmap initialization fix

### DIFF
--- a/benchmark/mipnerf360.sh
+++ b/benchmark/mipnerf360.sh
@@ -45,10 +45,11 @@ do
     echo "Running: $SCENE, Configuration: $CONFIG"
 
     # train without eval
+    nvidia-smi > $RESULT_DIR/train_$SCENE.log
     CUDA_VISIBLE_DEVICES=0 python train.py --config-name $CONFIG \
         use_wandb=False with_gui=False out_dir=$RESULT_DIR \
         path=data/mipnerf360/$SCENE experiment_name=$SCENE \
-        dataset.downsample_factor=$DATA_FACTOR > $RESULT_DIR/train_$SCENE.log
+        dataset.downsample_factor=$DATA_FACTOR >> $RESULT_DIR/train_$SCENE.log
 
 done
 

--- a/benchmark/scannetpp.sh
+++ b/benchmark/scannetpp.sh
@@ -39,8 +39,9 @@ do
     echo "Running: $SCENE, Configuration: $CONFIG"
 
     # train without eval
+    nvidia-smi > $RESULT_DIR/train_$SCENE.log
     CUDA_VISIBLE_DEVICES=0 python train.py --config-name $CONFIG \
         use_wandb=False with_gui=False out_dir=$RESULT_DIR \
-        path=data/scannetpp/$SCENE/dslr experiment_name=$SCENE > $RESULT_DIR/train_$SCENE.log
+        path=data/scannetpp/$SCENE/dslr experiment_name=$SCENE >> $RESULT_DIR/train_$SCENE.log
 
 done

--- a/threedgrut/render.py
+++ b/threedgrut/render.py
@@ -249,7 +249,10 @@ class Renderer:
             mean_lpips=mean_lpips,
             std_psnr=std_psnr,
         )
-        table["mean_inference_time"] = f"{'{:.2f}'.format(mean_inference_time)}" + " ms/frame"
+
+        if self.conf.render.enable_kernel_timings:
+            table["mean_inference_time"] = f"{'{:.2f}'.format(mean_inference_time)}" + " ms/frame"
+
         logger.log_table(f"⭐ Test Metrics - Step {self.global_step}", record=table)
 
         if self.writer is not None:

--- a/threedgrut/trainer.py
+++ b/threedgrut/trainer.py
@@ -480,7 +480,6 @@ class Trainer3DGRUT:
 
         loss = np.mean(metrics["losses"]["total_loss"])
         writer.add_scalar("loss/total/val", loss, global_step)
-        writer.add_scalar("train_loss_patches/total_loss", loss, global_step)  # hack to compare with 3DGS
         if self.conf.loss.use_l1:
             l1_loss = np.mean(metrics["losses"]["l1_loss"])
             writer.add_scalar("loss/l1/val", l1_loss, global_step)
@@ -549,6 +548,10 @@ class Trainer3DGRUT:
                     )
 
             writer.add_scalar("num_particles/train", self.model.num_gaussians, self.global_step)
+
+            # # NOTE: hack to easily compare with 3DGS
+            # writer.add_scalar("train_loss_patches/total_loss", loss, global_step)
+            # writer.add_scalar("gaussians/count", self.model.num_gaussians, self.global_step)
 
         logger.log_progress(
             task_name="Training",


### PR DESCRIPTION
It seems we accidentally normalized colmap color by 255 twice.

Changes:
- force colmap initialization to take uint8 colors, to avoid mistakes
- remove lidar initialization, no used
- some small tweak useful for debugging & logging
- fixed mean_inference_time = 0.0 log for training