### PR TITLE
Fix fisheye distortion calculation

### DIFF
--- a/threedgrut/datasets/dataset_colmap.py
+++ b/threedgrut/datasets/dataset_colmap.py
@@ -159,8 +159,8 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
             rays_o_cam = torch.zeros_like(rays_d_cam)
             return (
                 params.to_dict(),
-                torch.tensor(rays_o_cam, dtype=torch.float32, device=self.device).reshape(out_shape),
-                torch.tensor(rays_d_cam, dtype=torch.float32, device=self.device).reshape(out_shape),
+                rays_o_cam.to(torch.float32).reshape(out_shape),
+                rays_d_cam.to(torch.float32).reshape(out_shape),
                 type(params).__name__,
             )
 

--- a/threedgrut/trainer.py
+++ b/threedgrut/trainer.py
@@ -141,7 +141,7 @@ class Trainer3DGRUT:
             batch_size=1,
             shuffle=True,
             pin_memory=True,
-            persistent_workers=True,
+            persistent_workers=True if conf.num_workers > 0 else False,
         )
         val_dataloader = torch.utils.data.DataLoader(
             val_dataset,
@@ -149,7 +149,7 @@ class Trainer3DGRUT:
             batch_size=1,
             shuffle=False,
             pin_memory=True,
-            persistent_workers=True,
+            persistent_workers=True if conf.num_workers > 0 else False,
         )
         self.train_dataset = train_dataset
         self.train_dataloader = train_dataloader

--- a/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutProjector.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutProjector.cuh
@@ -302,7 +302,7 @@ struct GUTProjector : Params, UTParams {
         if constexpr (!Params::PerRayParticleFeatures) {
             particles.initializeFeatures(parameters);
             reinterpret_cast<TFeaturesVec*>(particlesPrecomputedFeaturesPtr)[particleIdx] =
-                particles.featuresCustomFromBuffer<false>(particleIdx, particleSensorRay / particleSensorDistance);
+                particles.template featuresCustomFromBuffer<false>(particleIdx, particleSensorRay / particleSensorDistance);
         }
 
         particlesProjectedPositionPtr[particleIdx]     = particleProjCenter;


### PR DESCRIPTION
- computation was incorrect
- a few minor tweak to fix warnings

Before (trained for 1000 steps)
![00000_bug](https://github.com/user-attachments/assets/440935c3-f562-4454-a5f2-e8f30031e3e0)

After
![00000_fix](https://github.com/user-attachments/assets/7d95a93d-1a57-492b-b4f9-4de6062fe0da)
