### PR TITLE
Decouple polyscope raygen+cameras & move functionality to kaolin

### DIFF
--- a/playground/playground.py
+++ b/playground/playground.py
@@ -1023,6 +1023,7 @@ class Playground:
             psim.TreePop()
 
     def _draw_render_widget(self):
+        window_w, window_h = ps.get_window_size()
         psim.SetNextItemOpen(True, psim.ImGuiCond_FirstUseEver)
         if psim.TreeNode("Render"):
             render_channel_changed, self.viz_render_style_ind = psim.Combo(
@@ -1055,7 +1056,7 @@ class Playground:
                     ps.CameraIntrinsics(
                         fov_vertical_deg=self.camera_fov,
                         fov_horizontal_deg=None,
-                        aspect=self.window_w / self.window_h
+                        aspect=window_w / window_h
                     ),
                     ps.get_view_camera_parameters().get_extrinsics()
                 )
@@ -1067,7 +1068,7 @@ class Playground:
             if psim.Button("Reset View"):
                 ps.reset_camera_to_home_view()
             if psim.IsItemHovered():
-                psim.SetNextWindowPos([self.window_w - psim.GetWindowWidth() - 120, 20])
+                psim.SetNextWindowPos([window_w - psim.GetWindowWidth() - 120, 20])
                 psim.Begin("Reset View", None, psim.ImGuiWindowFlags_NoTitleBar)
                 psim.TextUnformatted("View Navigation:")
                 psim.TextUnformatted("      Rotate: [left click drag]")
@@ -1163,7 +1164,7 @@ class Playground:
             psim.PopItemWidth()
 
             if self.video_recorder.mode == 'depth_of_field':
-                psim.PushItemWidth(100)
+                psim.PushItemWidth(75)
                 psim.SameLine()
                 _, self.video_recorder.min_dof = psim.SliderFloat(
                     "Min FoV", self.video_recorder.min_dof, v_min=0.0, v_max=24.0
@@ -1174,7 +1175,7 @@ class Playground:
                 )
                 psim.PopItemWidth()
 
-            psim.PushItemWidth(150)
+            psim.PushItemWidth(75)
             _, self.video_recorder.frames_between_cameras = psim.SliderInt(
                 "Frames Between", self.video_recorder.frames_between_cameras, v_min=1, v_max=120
             )

--- a/playground/playground.py
+++ b/playground/playground.py
@@ -1175,7 +1175,6 @@ class Playground:
 
             if self.video_recorder.mode == 'depth_of_field':
                 psim.PushItemWidth(75)
-                psim.SameLine()
                 _, self.video_recorder.min_dof = psim.SliderFloat(
                     "Min FoV", self.video_recorder.min_dof, v_min=0.0, v_max=24.0
                 )

--- a/playground/utils/kaolin_future/__init__.py
+++ b/playground/utils/kaolin_future/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/playground/utils/kaolin_future/conversions.py
+++ b/playground/utils/kaolin_future/conversions.py
@@ -1,0 +1,27 @@
+import torch
+import numpy as np
+import polyscope as ps
+from kaolin.render.camera import Camera
+
+
+def polyscope_to_kaolin_camera(ps_camera, width, height, near=1e-2, far=1e2, device='cpu'):
+    view_matrix = ps_camera.get_view_mat()
+    fov_y = ps_camera.get_fov_vertical_deg() * np.pi / 180.0    # to radians
+
+    return Camera.from_args(
+        view_matrix=view_matrix,
+        fov=fov_y,
+        width=width, height=height,
+        near=near, far=far,
+        dtype=torch.float64,
+        device=device
+    )
+
+
+def polyscope_from_kaolin_camera(camera: Camera):
+    view_matrix = camera.view_matrix()
+    ps_cam_param = ps.CameraParameters(
+        ps.CameraIntrinsics(fov_vertical_deg=camera.fov_y.detach().cpu().numpy(), aspect=camera.width / camera.height),
+        ps.CameraExtrinsics(mat=view_matrix[0].detach().cpu().numpy())
+    )
+    return ps_cam_param

--- a/playground/utils/kaolin_future/conversions.py
+++ b/playground/utils/kaolin_future/conversions.py
@@ -16,6 +16,7 @@
 import torch
 import numpy as np
 import polyscope as ps
+from typing import Union
 from kaolin.render.camera import Camera
 
 """
@@ -23,15 +24,32 @@ This module is to be included in next version of kaolin 0.18.0.
 As of March 26, 2025 the latest public release is kaolin 0.17.0, hence it's included here independently.
 """
 
-def polyscope_to_kaolin_camera(ps_camera, width, height, near=1e-2, far=1e2, device='cpu'):
-    """ Converts a polyscope camera (polyscope.CameraParameters) to kaolin Camera format (kaolin.render.camera.Camera).
+def polyscope_to_kaolin_camera(
+    ps_camera: ps.core.CameraParameters,
+    width: int,
+    height: int,
+    near: float = 1e-2,
+    far: float = 1e2,
+    device: Union[torch.device, str] = 'cpu'
+) -> Camera:
+    """ Converts a polyscope camera (polyscope.core.CameraParameters) to kaolin Camera format (kaolin.render.camera.Camera).
     The converted information includes the camera extrinsics, the image plane dimensions and field of view.
     Additional parameters that kaolin cameras assume, such as near, far plane and device
     can be passed explicitly if needed.
+
+    Args:
+        ps_camera (ps.core.CameraParameters): A polyscope camera object.
+        width (int): Image plane width in pixels.
+        height (int): Image plane height in pixels.
+        near (optional, float): near clipping plane, defines the min depth of the view frustrum.
+        far (optional, float): far clipping plane, define the max depth of the view frustrum.
+        device (optional, torch.device or str): the device on which camera parameters will be allocated. Default: cpu
+    Returns:
+        (kaolin.render.camera.Camera):
+            A kaolin camera object.
     """
     view_matrix = ps_camera.get_view_mat()
     fov_y = ps_camera.get_fov_vertical_deg() * np.pi / 180.0    # to radians
-
     return Camera.from_args(
         view_matrix=view_matrix,
         fov=fov_y,
@@ -42,10 +60,16 @@ def polyscope_to_kaolin_camera(ps_camera, width, height, near=1e-2, far=1e2, dev
     )
 
 
-def polyscope_from_kaolin_camera(camera: Camera):
-    """ Converts a kaolin camera (kaolin.render.camera.Camera) to a
-    polyscope camera format (polyscope.CameraParameters).
-    polysacope cameras are always assumed to exist on a cpu device.
+def polyscope_from_kaolin_camera(camera: Camera) -> ps.core.CameraParameters:
+    """ Converts a kaolin camera (kaolin.render.camera.Camera) to a polyscope camera format (polyscope.core.CameraParameters).
+    polyscope cameras are always assumed to exist on a cpu device.
+    The converted information includes the camera extrinsics, and intrinsics for the field of view.
+
+    Args:
+        camera (kaolin.render.camera.Camera): A polyscope camera object.
+    Returns:
+        (ps.core.CameraParameters):
+            A polyscope camera object.
     """
     view_matrix = camera.view_matrix()
     ps_cam_param = ps.CameraParameters(

--- a/playground/utils/kaolin_future/conversions.py
+++ b/playground/utils/kaolin_future/conversions.py
@@ -1,10 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import torch
 import numpy as np
 import polyscope as ps
 from kaolin.render.camera import Camera
 
+"""
+This module is to be included in next version of kaolin 0.18.0.
+As of March 26, 2025 the latest public release is kaolin 0.17.0, hence it's included here independently.
+"""
 
 def polyscope_to_kaolin_camera(ps_camera, width, height, near=1e-2, far=1e2, device='cpu'):
+    """ Converts a polyscope camera (polyscope.CameraParameters) to kaolin Camera format (kaolin.render.camera.Camera).
+    The converted information includes the camera extrinsics, the image plane dimensions and field of view.
+    Additional parameters that kaolin cameras assume, such as near, far plane and device
+    can be passed explicitly if needed.
+    """
     view_matrix = ps_camera.get_view_mat()
     fov_y = ps_camera.get_fov_vertical_deg() * np.pi / 180.0    # to radians
 
@@ -19,6 +43,10 @@ def polyscope_to_kaolin_camera(ps_camera, width, height, near=1e-2, far=1e2, dev
 
 
 def polyscope_from_kaolin_camera(camera: Camera):
+    """ Converts a kaolin camera (kaolin.render.camera.Camera) to a
+    polyscope camera format (polyscope.CameraParameters).
+    polysacope cameras are always assumed to exist on a cpu device.
+    """
     view_matrix = camera.view_matrix()
     ps_cam_param = ps.CameraParameters(
         ps.CameraIntrinsics(fov_vertical_deg=camera.fov_y.detach().cpu().numpy(), aspect=camera.width / camera.height),

--- a/playground/utils/kaolin_future/fisheye.py
+++ b/playground/utils/kaolin_future/fisheye.py
@@ -1,0 +1,96 @@
+import torch
+from typing import Optional
+from kaolin.render.camera import Camera, generate_centered_pixel_coords
+
+
+# -- Ray gen --
+def _to_ndc_coords(pixel_x, pixel_y, camera):
+    pixel_x = 2 * (pixel_x / camera.width) - 1.0
+    pixel_y = 2 * (pixel_y / camera.height) - 1.0
+    return pixel_x, pixel_y
+
+
+def generate_fisheye_rays(camera: Camera, coords_grid: Optional[torch.Tensor] = None, eps: float = 1e-9):
+    r"""Default ray generation function for perfect wide-angle fisheye cameras.
+
+    Fisheye cameras map wide angles to screen space by introducing distortion towards the edge of the image,
+    e.g. straight lines get mapped to curves in the projected image.
+
+    This raygen function uses equidistant mapping, which preserves angular distances
+    e.g. if two locations are THETA angles apart in world coordinates, they will be equally spaced in the
+    projected image.
+    The exact mapping is characterized by the field of view.
+
+    Note: This function does not concern non-ideal distortion parameters, such as
+    radial, tangential distortion parameters.
+
+    Args:
+        camera (kaolin.render.camera.Camera): A single camera object (batch size 1).
+        coords_grid (torch.FloatTensor, optional):
+            Pixel grid of ray-intersecting coordinates of shape :math:`(\text{H, W, 2})`.
+            Coordinates integer parts represent the pixel :math:`(\text{i, j})` coords, and the fraction part of
+            :math:`[\text{0,1}]` represents the location within the pixel itself.
+            For example, a coordinate of :math:`(\text{0.5, 0.5})` represents the center of the top-left pixel.
+        eps (float):
+            Numerical sensitivity parameter, used to prevent division by zero.
+
+    Returns:
+        (torch.FloatTensor, torch.FloatTensor, torch.BoolTensor):
+            First and second entries are the generated rays for the camera, as ray origins and ray direction tensors of
+            :math:`(\text{HxW, 3})`.
+
+            The third entry is a boolean mask that masks in which rays fall within the field of view of the camera
+            (rays outside the fov region shouldn't be rendered), of shape
+            :math:`(\text{HxW, 1})`.
+    """
+    assert len(camera) == 1, "generate_fisheye_rays() supports only camera input of batch size 1"
+    if coords_grid is None:
+        coords_grid = generate_centered_pixel_coords(camera.width, camera.height, device=camera.device)
+    else:
+        assert camera.device == coords_grid[0].device, \
+            f"Expected camera and coords_grid[0] to be on the same device, " \
+            f"but found {camera.device} and {coords_grid[0].device}."
+
+        assert camera.device == coords_grid[1].device, \
+            f"Expected camera and coords_grid[1] to be on the same device, " \
+            f"but found {camera.device} and {coords_grid[1].device}."
+
+    # coords_grid should remain immutable (a new tensor is implicitly created here)
+    pixel_y, pixel_x = coords_grid
+    pixel_x = pixel_x.to(camera.device, camera.dtype)
+    pixel_y = pixel_y.to(camera.device, camera.dtype)
+
+    # Account for principal point (offsets from the center)
+    pixel_x = pixel_x - camera.x0
+    pixel_y = pixel_y + camera.y0
+
+    # pixel values are now in range [-1, 1], both tensors are of shape res_y x res_x
+    u, v = _to_ndc_coords(pixel_x, pixel_y, camera)
+    r = torch.sqrt(u * u + v * v)
+    out_of_fov_mask = (r > 1.0)[:, :, None]
+
+    phi_cos = torch.where(torch.abs(r) > eps, u / r, 0.0)
+    phi_cos = torch.clamp(phi_cos, -1.0, 1.0)
+    phi = torch.arccos(phi_cos)
+    phi = torch.where(v < 0, -phi, phi)
+    theta = r * camera.fov(in_degrees=False) * 0.5
+
+    rays_dir = torch.stack(
+        [torch.cos(phi) * torch.sin(theta), torch.sin(phi) * torch.sin(theta), torch.cos(theta)], dim=2
+    )
+    mock_dir = torch.zeros_like(rays_dir)
+    mock_dir[:, :, 0] = -1.0
+    mock_dir[:, :, 1] = -.05
+    rays_dir = torch.where(out_of_fov_mask, mock_dir, rays_dir).unsqueeze(0)
+
+    # Generate ray origins in world coordinates
+    cam_center = camera.cam_pos()
+    rays_ori = (torch.tensor(cam_center, device=camera.device, dtype=torch.float32)
+                .reshape(1, 1, 1, 3)
+                .expand(1, camera.height, camera.width, 3))
+
+    rays_ori = rays_ori.reshape(-1, 3)
+    rays_dir = rays_dir.reshape(-1, 3)
+    out_of_fov_mask = out_of_fov_mask.reshape(-1, 1)
+
+    return rays_ori, rays_dir, out_of_fov_mask

--- a/playground/utils/kaolin_future/fisheye.py
+++ b/playground/utils/kaolin_future/fisheye.py
@@ -22,6 +22,7 @@ This module is to be included in next version of kaolin 0.18.0.
 As of March 26, 2025 the latest public release is kaolin 0.17.0, hence it's included here independently.
 """
 
+# Private function copied from kaolin, to be deleted
 def _to_ndc_coords(pixel_x, pixel_y, camera):
     pixel_x = 2 * (pixel_x / camera.width) - 1.0
     pixel_y = 2 * (pixel_y / camera.height) - 1.0

--- a/playground/utils/kaolin_future/fisheye.py
+++ b/playground/utils/kaolin_future/fisheye.py
@@ -1,16 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import torch
-from typing import Optional
+from typing import Optional, Tuple
 from kaolin.render.camera import Camera, generate_centered_pixel_coords
 
+"""
+This module is to be included in next version of kaolin 0.18.0.
+As of March 26, 2025 the latest public release is kaolin 0.17.0, hence it's included here independently.
+"""
 
-# -- Ray gen --
 def _to_ndc_coords(pixel_x, pixel_y, camera):
     pixel_x = 2 * (pixel_x / camera.width) - 1.0
     pixel_y = 2 * (pixel_y / camera.height) - 1.0
     return pixel_x, pixel_y
 
 
-def generate_fisheye_rays(camera: Camera, coords_grid: Optional[torch.Tensor] = None, eps: float = 1e-9):
+def generate_fisheye_rays(
+    camera: Camera,
+    coords_grid: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    eps: float = 1e-9
+):
     r"""Default ray generation function for perfect wide-angle fisheye cameras.
 
     Fisheye cameras map wide angles to screen space by introducing distortion towards the edge of the image,
@@ -26,8 +48,8 @@ def generate_fisheye_rays(camera: Camera, coords_grid: Optional[torch.Tensor] = 
 
     Args:
         camera (kaolin.render.camera.Camera): A single camera object (batch size 1).
-        coords_grid (torch.FloatTensor, optional):
-            Pixel grid of ray-intersecting coordinates of shape :math:`(\text{H, W, 2})`.
+        coords_grid (Tuple[torch.FloatTensor, torch.FloatTensor], optional):
+            x and y pixel grid of ray-intersecting coordinates of shape :math:`(\text{H, W})`.
             Coordinates integer parts represent the pixel :math:`(\text{i, j})` coords, and the fraction part of
             :math:`[\text{0,1}]` represents the location within the pixel itself.
             For example, a coordinate of :math:`(\text{0.5, 0.5})` represents the center of the top-left pixel.

--- a/playground/utils/kaolin_future/interpolated_cameras.py
+++ b/playground/utils/kaolin_future/interpolated_cameras.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import List, Iterator
 from scipy.special import comb
 from kaolin.render.camera import Camera
 import numpy as np
@@ -80,7 +80,7 @@ def interpolate_camera_on_polynomial_path(
     timestep: int,
     frames_between_cameras: int = 60,
     N: int = 3
-):
+) -> Camera:
     r"""Interpolates a camera from a smoothed path formed by a trajectory of cameras.
     The trajectory is assumed to have a list of at least 2 cameras, where the first and last cameras form a
     looped path.
@@ -91,7 +91,7 @@ def interpolate_camera_on_polynomial_path(
         timestep (int): Timestep used to interpolate a point on the smoothed trajectory.
             `timestep` can take any integer value to support continuous animations.
             e.g. if `timestep > len(trajectory) X frames_between_cameras`, the timestep will fold over using a
-            modulus.
+            modulus op.
         frames_between_cameras (int): Number of interpolated points generated between each pair of cameras on the
             trajectory. In essence, this value controls how detailed, or smooth the path is.
         N (int): determines the order polynomial, where the exact order is 2N + 1.
@@ -142,7 +142,7 @@ def interpolate_camera_on_spline_path(
     trajectory: List[Camera],
     timestep: int,
     frames_between_cameras: int = 60
-):
+) -> Camera:
     r"""Interpolates a camera from a linear path formed by a trajectory of cameras.
     The trajectory is assumed to have a list of at least 4 cameras.
     The interpolation is done using Catmull-Rom Splines.
@@ -217,7 +217,7 @@ def infinite_loop_camera_path_generator(
     trajectory: List[Camera],
     frames_between_cameras: int = 60,
     interpolation: str = 'polynomial',
-):
+) -> Iterator[Camera]:
     r"""A generator function for returning continuous camera objects an o smoothed path interpolated
     from a trajectory of cameras.
     The trajectory is assumed to have a list of at least 2 cameras, where the first and last cameras form a
@@ -254,11 +254,12 @@ def camera_path_generator(
     trajectory: List[Camera],
     frames_between_cameras: int = 60,
     interpolation: str = 'catmull_rom'
-):
-    r"""A generator function for returning continuous camera objects an o path interpolated on a spline
+) -> Iterator[Camera]:
+    r"""A finite generator function for returning continuous camera objects an o path interpolated
     from a trajectory of cameras.
-    The trajectory is assumed to have a list of at least 4 cameras.
     This generator is exhausted after it returns the last point on the path.
+    If interpolation is 'polynomial' - the trajectory is assumed to have a list of at least 2 cameras.
+    If interpolation is 'catmull_rom' - the trajectory is assumed to have a list of at least 4 cameras.
 
     Args:
         trajectory (List[kaolin.render.camera.Camera]): A trajectory of camera nodes, used to form a continuous path.

--- a/playground/utils/kaolin_future/interpolated_cameras.py
+++ b/playground/utils/kaolin_future/interpolated_cameras.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Iterator
-from scipy.special import comb
-from kaolin.render.camera import Camera
 import numpy as np
+import torch
+from typing import List, Iterator, Union, Callable
+from scipy.special import comb
+from kaolin.math import quat
+from kaolin.render.camera import Camera
 
 """
 This module is to be included in next version of kaolin 0.18.0.
@@ -35,14 +37,32 @@ __all__ = [
 def _smoothstep(
     x: float,
     x_min: float = 0.0,
-    x_max: float = 1,
+    x_max: float = 1.0,
     N: int = 3
 ):
+    """ Generalized smoothstep polynomials function, used for smooth interpolation of point x in [x_min, x_max].
+
+    This function implements a generalized smoothstep that creates a smooth transition
+    between 0 and 1 using higher-order polynomials. The resulting curve has zero 1st and 2nd
+    derivatives at both endpoints, ensuring smooth transitions.
+
+    The polynomial order is (2N + 1), where N controls the "smoothness" of the transition, i.e:
+    - N = 1: 3rd order (classic smoothstep)
+    - N = 3: 7th order (default, smoother transition)
+
+    Args:
+        x (float): Input value to be smoothly interpolated
+        x_min (float, optional): Minimum value of the input range. Defaults to 0.0.
+        x_max (float, optional): Maximum value of the input range. Defaults to 1.0.
+        N (int, optional): Smoothness factor, determines polynomial order (2N + 1). 
+            Defaults to 3 (7th order polynomial).
+
+    Returns:
+        float: Smoothly interpolated value in [0, 1]. The interpolation value is clamped to [0, 1].
+
+    See Also:
+        https://en.wikipedia.org/wiki/Smoothstep#Generalization_to_higher-order_equations
     """
-    Generalized smoothstep polynomials function, used for smooth interpolation of point x in [x_min, x_max].
-    N determines the order polynomial, where the exact order is 2N + 1.
-    """
-    # See: https://en.wikipedia.org/wiki/Smoothstep#Generalization_to_higher-order_equations
     x = np.clip((x - x_min) / (x_max - x_min), 0, 1)
 
     result = 0
@@ -54,18 +74,31 @@ def _smoothstep(
 
 
 def _catmull_rom(
-    t: float,
-    p0: float,
-    p1: float,
-    p2: float,
-    p3: float,
+    p0: Union[torch.Tensor, float, int],
+    p1: Union[torch.Tensor, float, int],
+    p2: Union[torch.Tensor, float, int],
+    p3: Union[torch.Tensor, float, int],
+    t: float
 ):
-    """
-    Interpolates a point on a Catmull-Rom spline, defined by control points p0, p1, p2, p3.
-    t determines the location of the point.
-    Catmull-Rom splines are guaranteed to pass through all control points.
-    """
+    """ Interpolates a scalar or n-dimensional point on a Catmull-Rom spline curve.
+    Catmull-Rom splines are C1 continuous cubic splines that guarantee to pass through their control points.
+    The spline is defined by four control points, where the interpolation occurs between p1 and p2, while p0 and p3
+    influence the tangents.
 
+    Args:
+        p0 (Union[torch.Tensor, float, int]): First control point, influences incoming tangent at p1
+        p1 (Union[torch.Tensor, float, int]): Second control point, spline passes through this point
+        p2 (Union[torch.Tensor, float, int]): Third control point, spline passes through this point
+        p3 (Union[torch.Tensor, float, int]): Fourth control point, influences outgoing tangent at p2
+        t (float): Interpolation parameter in [0, 1], where:
+            - t = 0 gives p1
+            - t = 1 gives p2
+            - 0 < t < 1 gives smooth interpolation between p1 and p2
+
+    Returns:
+        Union[torch.Tensor, float, int]: Interpolated point of the same type as input control points.
+        For tensors, the interpolation is applied element-wise.
+    """
     q_t = 0.5 * (
             (2.0 * p1) +
             (-p0 + p2) * t +
@@ -75,13 +108,164 @@ def _catmull_rom(
     return q_t
 
 
+def _lerp(
+    a: Union[torch.Tensor, float, int],
+    b: Union[torch.Tensor, float, int],
+    t: float
+) -> Union[torch.Tensor, float, int]:
+    """ Computes LERP, the Linear Interpolation function between two tensors, a and b.
+
+    Args:
+        a (torch.Tensor, float, int): Start tensor of arbitrary shape.
+        b (torch.Tensor, float, int): End tensor, of similar shape to a.
+        t (float): interpolation factor, a scalar between 0 and 1 that determines where the result lies on the
+            interpolation curve.
+
+    Returns:
+        torch.Tensor: Interpolated tensor, same shape as a and b.
+    """
+    return a * (1 - t) + b * t
+
+
+def _quaternion_angular_distance(q1, q2, eps=1e-6):
+    """ Computes the angular distance between two unit quaternions q1 and q2,
+    representing the minimum rotation angle needed to align them. The distance is
+    invariant to quaternion double-cover (meaning q and -q represent the same rotation).
+
+    The returned angle is in the range [0, pi] radians, where:
+    - 0 means the quaternions represent the same rotation
+    - pi means the quaternions represent opposite rotations
+    
+    The formula used is: theta = arccos(2(q1·q2)^2 - 1)
+    This gives the absolute angular difference regardless of rotation direction.
+
+    Input quaternions are assumed to be normalized unit quaternions.
+    
+    Args:
+        q1 (torch.Tensor): First unit quaternion of shape (4,)
+        q2 (torch.Tensor): Second unit quaternion of shape (4,)
+        eps (float, optional): Small value to handle numerical precision issues when
+            quaternions are nearly identical. Defaults to 1e-6.
+
+    Returns:
+        torch.Tensor: Angular distance in radians, shape (1,).
+        Returns 0 if the quaternions represent the same or nearly same rotation
+        (within eps tolerance).
+    """
+    q_dot = torch.dot(q1, q2)
+    if abs(q_dot - 1.0) < eps:
+        return q1.new_zeros(1)
+    return torch.arccos(2 * q_dot * q_dot - 1.0)
+
+
+def _catmull_rom_q(q0, q1, q2, q3, t, alpha=0.5, eps=1e-6):
+    """Interpolates a quaternion using a Catmull-Rom spline formulation.
+    Similar to _catmull_rom(), this function ensures the interpolation results in a quaternion on the unit sphere.
+
+    Quaternion interpolation is computed using a pyramid formulation of spherical linear
+    interpolation (SLERP) operations. The interpolation is performed between four control quaternions,
+    with the result guaranteed to pass through q1 and q2. The spacing between quaternions is controlled
+    by their angular distances raised to a power alpha, allowing for different parameterizations.
+    Therefore, the interpolation may slow down near control points.
+
+    All input quaternions are assumed to be normalized unit quaternions.
+    
+    See also: 
+        https://en.wikipedia.org/wiki/Centripetal_Catmull-Rom_spline
+
+    Args:
+        q0 (torch.Tensor): First control quaternion of shape (4,), influences the "approach" to q1
+        q1 (torch.Tensor): Second control quaternion of shape (4,), interpolation will pass through this point
+        q2 (torch.Tensor): Third control quaternion of shape (4,), interpolation will pass through this point
+        q3 (torch.Tensor): Fourth control quaternion of shape (4,), influences the "exit" from q2
+        t (float): Interpolation parameter in [0,1], determines position along the spline
+        alpha (float, optional): Controls the parameterization of the curve:
+            - alpha = 0.0: uniform spacing (constant speed, but may be too fast/slow in places)
+            - alpha = 0.5: centripetal (usually provides good balance of speed and smoothness)
+            - alpha = 1.0: chordal/arc-length (most uniform speed but may overshoot)
+            Defaults to 0.5 (centripetal).
+        eps (float, optional): Small value to avoid division by zero in angle calculations.
+            Defaults to 1e-6.
+    """
+    t0 = 0.0
+    t1 = _quaternion_angular_distance(q0, q1) ** alpha + t0
+    t2 = _quaternion_angular_distance(q1, q2) ** alpha + t1
+    t3 = _quaternion_angular_distance(q2, q3) ** alpha + t2
+
+    # Scale interpolation arg to [t1, t2]
+    t = t * (t2 - t1) + t1
+
+    tA1 = (t - t0) / (t1 - t0) if abs(t1 - t0) > eps else t0
+    tA2 = (t - t1) / (t2 - t1) if abs(t2 - t1) > eps else t1
+    tA3 = (t - t2) / (t3 - t2) if abs(t3 - t2) > eps else t2
+    A1 = _slerp_q(q0, q1, t=tA1)
+    A2 = _slerp_q(q1, q2, t=tA2)
+    A3 = _slerp_q(q2, q3, t=tA3)
+
+    tB1 = (t - t0) / (t2 - t0) if abs(t2 - t0) > eps else t0
+    tB2 = (t - t1) / (t3 - t1) if abs(t3 - t1) > eps else t1
+    B1 = _slerp_q(A1, A2, t=tB1)
+    B2 = _slerp_q(A2, A3, t=tB2)
+
+    tC = (t - t1) / (t2 - t1) if abs(t2 - t1) > eps else t1
+    C = _slerp_q(B1, B2, t=tC)
+
+    # Quaternion should be normalized, but enforce as a failsafe
+    return quat.quat_unit(C)
+
+
+def _slerp_q(a: torch.Tensor, b: torch.Tensor, t: float, eps=1e-6):
+    """ Computes SLERP, the Spherical Linear Interpolation function between two quaternions, a and b.
+    Args:
+        a (torch.Tensor): Start unit quaternion of shape (4,).
+        b (torch.Tensor): End unit quaternion of shape (4,).
+        t (float): Interpolation factor, a scalar between 0 and 1 that determines where the result lies on the
+            interpolation curve.
+        eps (float): Numerical precision parameter, to avoid division by zero if the angle between a,b is very small.
+    Returns:
+        torch.Tensor: Interpolated unit quaternion of shape (4,).
+    """
+    dot = torch.dot(a, b)
+    # If dot is negative, slerp will take the longer path along the sphere. In that case, negate to take the shortest path
+    if dot < 0.0:
+        dot = -dot
+        b = -b
+    theta = torch.acos(torch.clamp(dot, -1.0, 1.0))  # Angle between a, b
+    # If angle is too small, resort to LeRP to avoid division by zero
+    if theta < eps:
+        return (1.0 - t) * a + t * b
+    sin_theta = torch.sin(theta)
+    wa = torch.sin((1.0 - t) * theta) / sin_theta
+    wb = torch.sin(t * theta) / sin_theta
+    return wa * a + wb * b
+
+
+def _lerp_q(a: torch.Tensor, b: torch.Tensor, t: float):
+    """ Computes LERP, the Linear Interpolation function between two quaternions, a and b.
+    Args:
+        a (torch.Tensor): Start unit quaternion of shape (4,).
+        b (torch.Tensor): End unit quaternion of shape (4,).
+        t (float): interpolation factor, a scalar between 0 and 1 that determines where the result lies on the
+            interpolation curve.
+    Returns:
+        torch.Tensor: Interpolated unit quaternion of shape (4,).
+    """
+    dot = torch.dot(a, b)
+    # If dot is negative, lerp will take the longer path along the sphere.
+    # Negate to take the shortest path here
+    if dot < 0.0:
+        b = -b
+    return a * (1 - t) + b * t
+
+
+
 def interpolate_camera_on_polynomial_path(
     trajectory: List[Camera],
     timestep: int,
     frames_between_cameras: int = 60,
     N: int = 3
 ) -> Camera:
-    r"""Interpolates a camera from a smoothed path formed by a trajectory of cameras.
+    """ Interpolates a camera from a smoothed path formed by a trajectory of cameras.
     The trajectory is assumed to have a list of at least 2 cameras, where the first and last cameras form a
     looped path.
     The interpolation is done using a generalized polynomial function.
@@ -101,35 +285,36 @@ def interpolate_camera_on_polynomial_path(
             An interpolated camera object formed by the cameras trajectory.
     """
     traj_idx = (timestep // frames_between_cameras) % len(trajectory)
-
     cam1 = trajectory[traj_idx]
     cam2 = trajectory[traj_idx + 1]
+    assert cam1.lens_type == cam2.lens_type, \
+        ('interpolate_camera_on_polynomial_path() only support interpolation of cameras with the same lens type, '
+         f'but received cameras of types {cam1.lens_type} and {cam2.lens_type}.')
+    Xs = _smoothstep(np.linspace(0.0, 1.0, frames_between_cameras), N=N)
+    x = Xs[timestep % frames_between_cameras]   # Interpolation variable
 
-    eye_1, target_1, up_1 = cam1.cam_pos(), cam1.cam_forward(), cam1.cam_up()
-    eye_2, target_2, up_2 = cam2.cam_pos(), cam2.cam_forward(), cam2.cam_up()
-    width_1, height_1 = cam1.width, cam1.height
-    width_2, height_2 = cam2.width, cam2.height
+    # Extrinsics
+    q1 = quat.quat_from_rot33(cam1.R).squeeze(0)
+    q2 = quat.quat_from_rot33(cam2.R).squeeze(0)
+    q = _slerp_q(q1, q2, x)
+    cam_R = quat.rot33_from_quat(q.unsqueeze(0))
+    cam_t = _lerp(cam1.t, cam2.t, x)
+    view_matrix = torch.eye(4, dtype=q1.dtype, device=q1.device).unsqueeze(0)
+    view_matrix[0, :3, :3] = cam_R
+    view_matrix[0, :3, 3] = cam_t[0,:,0]
 
+    # Intrinsics
     intrinsics = dict()
     if cam1.lens_type == 'pinhole' and cam2.lens_type == 'pinhole':
         intrinsics['fov'] = (cam1.fov(in_degrees=False), cam2.fov(in_degrees=False))
     elif cam1.lens_type == 'ortho' and cam2.lens_type == 'ortho':
         intrinsics['fov_distance'] = (cam1.fov_distance(), cam2.fov_distance())
-
-    Xs = _smoothstep(np.linspace(0.0, 1.0, frames_between_cameras), N=N)
-    x = Xs[timestep % frames_between_cameras]
-
-    eye = eye_1 * (1 - x) + eye_2 * x
-    target = target_1 * (1 - x) + target_2 * x
-    up = up_1 * (1 - x) + up_2 * x
-    width = round(width_1 * (1 - x) + width_2 * x)
-    height = round(height_1 * (1 - x) + height_2 * x)
-    intrinsics = {intr_name: intr_val[0] * (1 - x) + intr_val[1] * x for intr_name, intr_val in intrinsics.items()}
+    intrinsics = {intr_name: _lerp(intr_val[0],intr_val[1], x) for intr_name, intr_val in intrinsics.items()}
+    width = round(_lerp(cam1.width, cam2.width, x))
+    height = round(_lerp(cam1.height, cam2.height, x))
 
     cam = Camera.from_args(
-        eye=eye,
-        at=eye - target,
-        up=up,
+        view_matrix=view_matrix,
         width=width, height=height,
         device=cam1.device,
         **intrinsics
@@ -143,9 +328,9 @@ def interpolate_camera_on_spline_path(
     timestep: int,
     frames_between_cameras: int = 60
 ) -> Camera:
-    r"""Interpolates a camera from a linear path formed by a trajectory of cameras.
+    """ Interpolates a camera from a linear path formed by a trajectory of cameras.
     The trajectory is assumed to have a list of at least 4 cameras.
-    The interpolation is done using Catmull-Rom Splines.
+    The interpolation is done using Catmull-Rom Splines that guarantee to pass through the control points.
 
     Args:
         trajectory (List[kaolin.render.camera.Camera]): A trajectory of camera nodes, used to form a continuous path.
@@ -161,50 +346,53 @@ def interpolate_camera_on_spline_path(
             An interpolated camera object formed by the cameras trajectory.
     """
     traj_idx = (timestep // frames_between_cameras) % len(trajectory)
-
     traj_idx = min(max(traj_idx, 0), len(trajectory) - 3)
-
     cam1 = trajectory[traj_idx - 1]
     cam2 = trajectory[traj_idx]
     cam3 = trajectory[traj_idx + 1]
     cam4 = trajectory[traj_idx + 2]
+    assert cam1.lens_type == cam2.lens_type == cam3.lens_type == cam4.lens_type, \
+        ('interpolate_camera_on_spline_path() only support interpolation of cameras with the same lens type, '
+         f'but received cameras of types {cam1.lens_type}, {cam2.lens_type}, {cam3.lens_type}, {cam4.lens_type}.')
+    Xs = np.linspace(0.0, 1.0, frames_between_cameras)
+    x = Xs[timestep % frames_between_cameras]   # Interpolation variable
 
-    eye_1, target_1, up_1 = cam1.cam_pos(), cam1.cam_forward(), cam1.cam_up()
-    eye_2, target_2, up_2 = cam2.cam_pos(), cam2.cam_forward(), cam2.cam_up()
-    eye_3, target_3, up_3 = cam3.cam_pos(), cam3.cam_forward(), cam3.cam_up()
-    eye_4, target_4, up_4 = cam4.cam_pos(), cam4.cam_forward(), cam4.cam_up()
-    width_1, height_1 = cam1.width, cam1.height
-    width_2, height_2 = cam2.width, cam2.height
-    width_3, height_3 = cam3.width, cam3.height
-    width_4, height_4 = cam4.width, cam4.height
+    # Extrinsics
+    q1 = quat.quat_from_rot33(cam1.R).squeeze(0)
+    q2 = quat.quat_from_rot33(cam2.R).squeeze(0)
+    q3 = quat.quat_from_rot33(cam3.R).squeeze(0)
+    q4 = quat.quat_from_rot33(cam4.R).squeeze(0)
+    q = _catmull_rom_q(q1, q2, q3, q4, x)
+    cam_R = quat.rot33_from_quat(q.unsqueeze(0))
+    cam_t = _catmull_rom(cam1.t, cam2.t, cam3.t, cam4.t, x)
+    view_matrix = torch.eye(4, dtype=q1.dtype, device=q1.device).unsqueeze(0)
+    view_matrix[0, :3, :3] = cam_R
+    view_matrix[0, :3, 3] = cam_t[0,:,0]
 
+    # Intrinsics
     intrinsics = dict()
-    if cam1.lens_type == 'pinhole' and cam2.lens_type == 'pinhole':
+    if cam1.lens_type == 'pinhole':
         intrinsics['fov'] = (
             cam1.fov(in_degrees=False),
             cam2.fov(in_degrees=False),
             cam3.fov(in_degrees=False),
             cam4.fov(in_degrees=False)
         )
-    elif cam1.lens_type == 'ortho' and cam2.lens_type == 'ortho':
+    elif cam1.lens_type == 'ortho':
         intrinsics['fov_distance'] = \
             (cam1.fov_distance(), cam2.fov_distance(), cam3.fov_distance(), cam4.fov_distance())
+    else:
+        raise ValueError(f'Unsupported lens type {cam1.lens_type}')
 
-    Xs = np.linspace(0.0, 1.0, frames_between_cameras)
-    t = Xs[timestep % frames_between_cameras]
 
-    eye = _catmull_rom(t, eye_1, eye_2, eye_3, eye_4)
-    target = _catmull_rom(t, target_1, target_2, target_3, target_4)
-    up = _catmull_rom(t, up_1, up_2, up_3, up_4)
-    width = round(_catmull_rom(t, width_1, width_2, width_3, width_4))
-    height = round(_catmull_rom(t, height_1, height_2, height_3, height_4))
-    intrinsics = {intr_name: _catmull_rom(t, intr_val[0], intr_val[1], intr_val[2], intr_val[3])
+    intrinsics = {intr_name: _catmull_rom(intr_val[0], intr_val[1], intr_val[2], intr_val[3], x)
                   for intr_name, intr_val in intrinsics.items()}
+    width = round(_catmull_rom(cam1.width, cam2.width, cam3.width, cam4.width, x))
+    height = round(_catmull_rom(cam1.height, cam2.height, cam3.height, cam4.height, x))
 
+    # Create camera from view matrix
     cam = Camera.from_args(
-        eye=eye,
-        at=eye - target,
-        up=up,
+        view_matrix=view_matrix,
         width=width, height=height,
         device=cam1.device,
         **intrinsics
@@ -213,12 +401,35 @@ def interpolate_camera_on_spline_path(
     return cam
 
 
+def get_interpolator(interpolation: str, trajectory: List[Camera]) -> Callable:
+    """ Returns an interpolator function based on the interpolation type and trajectory.
+    Args:
+        interpolation (str): Type of interpolation function used:
+            'polynomial' uses a smoothstep polynomial function which tends to overshoot around the keyframes.
+                This interpolator is fitting for paths orbiting an object of interest.
+            'catmull_rom' uses a spline defined by 4 control points, guaranteed to pass precisely through the keyframes.
+    Returns:
+        Callable: An interpolator function that takes a trajectory, timestep, and frames_between_cameras, and returns a camera.
+    """
+    if interpolation == 'polynomial':
+        interpolator =  interpolate_camera_on_polynomial_path
+        if len(trajectory) < 2:
+            raise ValueError("For polynomial interpolation, cameras trajectory must have at least 2 cameras.")
+    elif interpolation == 'catmull_rom':
+        interpolator =  interpolate_camera_on_spline_path
+        if len(trajectory) < 4:
+            raise ValueError("For catmull_rom interpolation, cameras trajectory must have at least 4 cameras.")
+    else:
+        raise ValueError("Unknown interpolation function specified. Valid options: 'polynomial', 'catmull_rom'.")
+    return interpolator
+
+
 def infinite_loop_camera_path_generator(
     trajectory: List[Camera],
     frames_between_cameras: int = 60,
     interpolation: str = 'polynomial',
 ) -> Iterator[Camera]:
-    r"""A generator function for returning continuous camera objects an o smoothed path interpolated
+    """ A generator function for returning continuous camera objects an on a smoothed path interpolated
     from a trajectory of cameras.
     The trajectory is assumed to have a list of at least 2 cameras, where the first and last cameras form a
     looped path.
@@ -237,17 +448,16 @@ def infinite_loop_camera_path_generator(
         (kaolin.render.camera.Camera):
             An interpolated camera object formed by the cameras trajectory.
     """
-    if interpolation == 'polynomial':
-        interpolator =  interpolate_camera_on_polynomial_path
-    elif interpolation == 'catmull_rom':
-        interpolator =  interpolate_camera_on_spline_path
-    else:
-        raise ValueError("Unknown interpolation function specified. Valid options: 'polynomial', 'catmull_rom'.")
+    interpolator = get_interpolator(interpolation, trajectory)
 
-    timestep = 0
+    _trajectory = [trajectory[-1]] + trajectory + [trajectory[0], trajectory[1]]
+    timestep = frames_between_cameras
+
     while True:
-        yield interpolator(trajectory, timestep, frames_between_cameras)
-        timestep += 1
+        yield interpolator(_trajectory, timestep, frames_between_cameras)
+        timestep = max(
+            (timestep + 1) % ((len(trajectory) + 1) * frames_between_cameras), frames_between_cameras
+        )
 
 
 def camera_path_generator(
@@ -255,7 +465,7 @@ def camera_path_generator(
     frames_between_cameras: int = 60,
     interpolation: str = 'catmull_rom'
 ) -> Iterator[Camera]:
-    r"""A finite generator function for returning continuous camera objects an o path interpolated
+    """ A finite generator function for returning continuous camera objects an o path interpolated
     from a trajectory of cameras.
     This generator is exhausted after it returns the last point on the path.
     If interpolation is 'polynomial' - the trajectory is assumed to have a list of at least 2 cameras.
@@ -274,12 +484,7 @@ def camera_path_generator(
         (kaolin.render.camera.Camera):
             An interpolated camera object formed by the cameras trajectory.
     """
-    if interpolation == 'polynomial':
-        interpolator =  interpolate_camera_on_polynomial_path
-    elif interpolation == 'catmull_rom':
-        interpolator =  interpolate_camera_on_spline_path
-    else:
-        raise ValueError("Unknown interpolation function specified. Valid options: 'polynomial', 'catmull_rom'.")
+    interpolator = get_interpolator(interpolation, trajectory)
 
     _trajectory = [trajectory[0]] + trajectory + [trajectory[-1], trajectory[-1]]
     timestep = frames_between_cameras

--- a/playground/utils/kaolin_future/interpolated_cameras.py
+++ b/playground/utils/kaolin_future/interpolated_cameras.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+from scipy.special import comb
+from kaolin.render.camera import Camera
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+"""
+This module is to be included in next version of kaolin 0.18.0.
+As of March 26, 2025 the latest public release is kaolin 0.17.0, hence it's included here independently.
+"""
+
+
+__all__ = [
+    'interpolate_camera_on_polynomial_path',
+    'interpolate_camera_on_spline_path',
+    'smooth_cyclic_camera_path_generator',
+    'linear_camera_path_generator'
+]
+
+
+def _smoothstep(
+    x: float,
+    x_min: float = 0.0,
+    x_max: float = 1,
+    N: int = 1
+):
+    """
+    Generalized smoothstep polynomials function, used for smooth interpolation of point x in [x_min, x_max].
+    N determines the order polynomial, where the exact order is 2N + 1.
+    """
+    # See: https://en.wikipedia.org/wiki/Smoothstep#Generalization_to_higher-order_equations
+    x = np.clip((x - x_min) / (x_max - x_min), 0, 1)
+
+    result = 0
+    for n in range(0, N + 1):
+         result += comb(N + n, n) * comb(2 * N + 1, N - n) * (-x) ** n
+
+    result *= x ** (N + 1)
+    return result
+
+
+def _catmull_rom(
+    t: float,
+    p0: float,
+    p1: float,
+    p2: float,
+    p3: float,
+):
+    """
+    Interpolates a point on a Catmull-Rom spline, defined by control points p0, p1, p2, p3.
+    t determines the location of the point.
+    Catmull-Rom splines are guaranteed to pass through all control points.
+    """
+
+    q_t = 0.5 * (
+            (2.0 * p1) +
+            (-p0 + p2) * t +
+            (2*p0 - 5*p1 + 4*p2 - p3) * t**2 +
+            (-p0 + 3*p1- 3*p2 + p3) * t**3
+    )
+    return q_t
+
+
+def interpolate_camera_on_polynomial_path(
+    trajectory: List[Camera],
+    timestep: int,
+    frames_between_cameras: int = 60
+):
+    r"""Interpolates a camera from a smoothed path formed by a trajectory of cameras.
+    The trajectory is assumed to have a list of at least 2 cameras, where the first and last cameras form a
+    looped path.
+    The interpolation is done using a generalized polynomial function.
+
+    Args:
+        trajectory (List[kaolin.render.camera.Camera]): A trajectory of camera nodes, used to form a continuous path.
+        timestep (int): Timestep used to interpolate a point on the smoothed trajectory.
+            `timestep` can take any integer value to support continuous animations.
+            e.g. if `timestep > len(trajectory) X frames_between_cameras`, the timestep will fold over using a
+            modulus.
+        frames_between_cameras (int): Number of interpolated points generated between each pair of cameras on the
+            trajectory. In essence, this value controls how detailed, or smooth the path is.
+
+    Returns:
+        (kaolin.render.camera.Camera):
+            An interpolated camera object formed by the cameras trajectory.
+    """
+    traj_idx = (timestep // frames_between_cameras) % len(trajectory)
+
+    cam1 = trajectory[traj_idx - 1]
+    cam2 = trajectory[traj_idx]
+
+    eye_1, target_1, up_1 = cam1.cam_pos(), cam1.cam_forward(), cam1.cam_up()
+    eye_2, target_2, up_2 = cam2.cam_pos(), cam2.cam_forward(), cam2.cam_up()
+    width_1, height_1 = cam1.width, cam1.height
+    width_2, height_2 = cam2.width, cam2.height
+
+    intrinsics = dict()
+    if cam1.lens_type == 'pinhole' and cam2.lens_type == 'pinhole':
+        intrinsics['fov'] = (cam1.fov(), cam2.fov())
+    elif cam1.lens_type == 'ortho' and cam2.lens_type == 'ortho':
+        intrinsics['fov_distance'] = (cam1.fov_distance(), cam2.fov_distance())
+
+    Xs = _smoothstep(np.linspace(0.0, 1.0, frames_between_cameras))
+    x = Xs[timestep % frames_between_cameras]
+
+    eye = eye_1 * (1 - x) + eye_2 * x
+    target = target_1 * (1 - x) + target_2 * x
+    up = up_1 * (1 - x) + up_2 * x
+    width = width_1 * (1 - x) + width_2 * x
+    height = height_1 * (1 - x) + height_2 * x
+    intrinsics = {intr_name: intr_val[0] * (1 - x) + intr_val[1] * x for intr_name, intr_val in intrinsics.items()}
+
+    cam = Camera.from_args(
+        eye=eye,
+        at=target,
+        up=up,
+        width=width, height=height,
+        device=cam1.device,
+        **intrinsics
+    )
+
+    return cam
+
+
+def interpolate_camera_on_spline_path(
+    trajectory: List[Camera],
+    timestep: int,
+    frames_between_cameras: int = 60
+):
+    r"""Interpolates a camera from a linear path formed by a trajectory of cameras.
+    The trajectory is assumed to have a list of at least 4 cameras.
+    The interpolation is done using Catmull-Rom Splines.
+
+    Args:
+        trajectory (List[kaolin.render.camera.Camera]): A trajectory of camera nodes, used to form a continuous path.
+        timestep (int): Timestep used to interpolate a point on the smoothed trajectory.
+            `timestep` can take any integer value to support continuous animations.
+            e.g. if `timestep > len(trajectory) X frames_between_cameras`, the timestep will fold over using a
+            modulus.
+        frames_between_cameras (int): Number of interpolated points generated between each pair of cameras on the
+            trajectory. In essence, this value controls how detailed, or smooth the path is.
+
+    Returns:
+        (kaolin.render.camera.Camera):
+            An interpolated camera object formed by the cameras trajectory.
+    """
+    traj_idx = (timestep // frames_between_cameras) % len(trajectory)
+
+    traj_idx = min(max(traj_idx, 0), len(trajectory) - 3)
+
+    cam1 = trajectory[traj_idx - 1]
+    cam2 = trajectory[traj_idx]
+    cam3 = trajectory[traj_idx + 1]
+    cam4 = trajectory[traj_idx + 2]
+
+    eye_1, target_1, up_1 = cam1.cam_pos(), cam1.cam_forward(), cam1.cam_up()
+    eye_2, target_2, up_2 = cam2.cam_pos(), cam2.cam_forward(), cam2.cam_up()
+    eye_3, target_3, up_3 = cam3.cam_pos(), cam3.cam_forward(), cam3.cam_up()
+    eye_4, target_4, up_4 = cam4.cam_pos(), cam4.cam_forward(), cam4.cam_up()
+    width_1, height_1 = cam1.width, cam1.height
+    width_2, height_2 = cam2.width, cam2.height
+    width_3, height_3 = cam3.width, cam3.height
+    width_4, height_4 = cam4.width, cam4.height
+
+    intrinsics = dict()
+    if cam1.lens_type == 'pinhole' and cam2.lens_type == 'pinhole':
+        intrinsics['fov'] = (
+            cam1.fov(in_degrees=False),
+            cam2.fov(in_degrees=False),
+            cam3.fov(in_degrees=False),
+            cam4.fov(in_degrees=False)
+        )
+    elif cam1.lens_type == 'ortho' and cam2.lens_type == 'ortho':
+        intrinsics['fov_distance'] = \
+            (cam1.fov_distance(), cam2.fov_distance(), cam3.fov_distance(), cam4.fov_distance())
+
+    Xs = np.linspace(0.0, 1.0, frames_between_cameras)
+    t = Xs[timestep % frames_between_cameras]
+
+    eye = _catmull_rom(t, eye_1, eye_2, eye_3, eye_4)
+    target = _catmull_rom(t, target_1, target_2, target_3, target_4)
+    up = _catmull_rom(t, up_1, up_2, up_3, up_4)
+    width = _catmull_rom(t, width_1, width_2, width_3, width_4)
+    height = _catmull_rom(t, height_1, height_2, height_3, height_4)
+    intrinsics = {intr_name: _catmull_rom(t, intr_val[0], intr_val[1], intr_val[2], intr_val[3])
+                  for intr_name, intr_val in intrinsics.items()}
+
+    cam = Camera.from_args(
+        eye=eye,
+        at=eye - target,
+        up=up,
+        width=width, height=height,
+        device=cam1.device,
+        **intrinsics
+    )
+
+    return cam
+
+
+def smooth_cyclic_camera_path_generator(
+    trajectory: List[Camera],
+    frames_between_cameras: int = 60
+):
+    r"""A generator function for returning continuous camera objects an o smoothed path interpolated
+    from a trajectory of cameras.
+    The trajectory is assumed to have a list of at least 2 cameras, where the first and last cameras form a
+    looped path.
+    This generator is therefore never exhausted, and can be invoked infinitely to generate continuous camera motion.
+
+    Args:
+        trajectory (List[kaolin.render.camera.Camera]): A trajectory of camera nodes, used to form a continuous path.
+        frames_between_cameras (int): Number of interpolated points generated between each pair of cameras on the
+            trajectory. In essence, this value controls how detailed, or smooth the path is.
+
+    Returns:
+        (kaolin.render.camera.Camera):
+            An interpolated camera object formed by the cameras trajectory.
+    """
+    timestep = 0
+    while True:
+        yield interpolate_camera_on_polynomial_path(trajectory, timestep, frames_between_cameras)
+        timestep += 1
+
+
+def linear_camera_path_generator(
+    trajectory: List[Camera],
+    frames_between_cameras: int = 60
+):
+    r"""A generator function for returning continuous camera objects an o path interpolated on a spline
+    from a trajectory of cameras.
+    The trajectory is assumed to have a list of at least 4 cameras.
+    This generator is exhausted after it returns the last point on the path.
+
+    Args:
+        trajectory (List[kaolin.render.camera.Camera]): A trajectory of camera nodes, used to form a continuous path.
+        frames_between_cameras (int): Number of interpolated points generated between each pair of cameras on the
+            trajectory. In essence, this value controls how detailed, or smooth the path is.
+
+    Returns:
+        (kaolin.render.camera.Camera):
+            An interpolated camera object formed by the cameras trajectory.
+    """
+    _trajectory = trajectory + [trajectory[-1]]
+    timestep = 0
+    while True:
+        yield interpolate_camera_on_spline_path(_trajectory, timestep, frames_between_cameras)
+        timestep += 1
+
+        traj_idx = (timestep // frames_between_cameras) % len(_trajectory)
+        if traj_idx == len(_trajectory) - 2:
+            break

--- a/playground/utils/kaolin_future/interpolated_cameras.py
+++ b/playground/utils/kaolin_future/interpolated_cameras.py
@@ -1,11 +1,11 @@
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,8 +17,6 @@ from typing import List
 from scipy.special import comb
 from kaolin.render.camera import Camera
 import numpy as np
-import torch
-import torch.nn.functional as F
 
 """
 This module is to be included in next version of kaolin 0.18.0.

--- a/playground/utils/kaolin_future/interpolated_cameras.py
+++ b/playground/utils/kaolin_future/interpolated_cameras.py
@@ -27,8 +27,8 @@ As of March 26, 2025 the latest public release is kaolin 0.17.0, hence it's incl
 __all__ = [
     'interpolate_camera_on_polynomial_path',
     'interpolate_camera_on_spline_path',
-    'smooth_cyclic_camera_path_generator',
-    'linear_camera_path_generator'
+    'infinite_loop_camera_path_generator',
+    'camera_path_generator'
 ]
 
 
@@ -36,7 +36,7 @@ def _smoothstep(
     x: float,
     x_min: float = 0.0,
     x_max: float = 1,
-    N: int = 1
+    N: int = 3
 ):
     """
     Generalized smoothstep polynomials function, used for smooth interpolation of point x in [x_min, x_max].
@@ -78,7 +78,8 @@ def _catmull_rom(
 def interpolate_camera_on_polynomial_path(
     trajectory: List[Camera],
     timestep: int,
-    frames_between_cameras: int = 60
+    frames_between_cameras: int = 60,
+    N: int = 3
 ):
     r"""Interpolates a camera from a smoothed path formed by a trajectory of cameras.
     The trajectory is assumed to have a list of at least 2 cameras, where the first and last cameras form a
@@ -93,6 +94,7 @@ def interpolate_camera_on_polynomial_path(
             modulus.
         frames_between_cameras (int): Number of interpolated points generated between each pair of cameras on the
             trajectory. In essence, this value controls how detailed, or smooth the path is.
+        N (int): determines the order polynomial, where the exact order is 2N + 1.
 
     Returns:
         (kaolin.render.camera.Camera):
@@ -100,8 +102,8 @@ def interpolate_camera_on_polynomial_path(
     """
     traj_idx = (timestep // frames_between_cameras) % len(trajectory)
 
-    cam1 = trajectory[traj_idx - 1]
-    cam2 = trajectory[traj_idx]
+    cam1 = trajectory[traj_idx]
+    cam2 = trajectory[traj_idx + 1]
 
     eye_1, target_1, up_1 = cam1.cam_pos(), cam1.cam_forward(), cam1.cam_up()
     eye_2, target_2, up_2 = cam2.cam_pos(), cam2.cam_forward(), cam2.cam_up()
@@ -110,23 +112,23 @@ def interpolate_camera_on_polynomial_path(
 
     intrinsics = dict()
     if cam1.lens_type == 'pinhole' and cam2.lens_type == 'pinhole':
-        intrinsics['fov'] = (cam1.fov(), cam2.fov())
+        intrinsics['fov'] = (cam1.fov(in_degrees=False), cam2.fov(in_degrees=False))
     elif cam1.lens_type == 'ortho' and cam2.lens_type == 'ortho':
         intrinsics['fov_distance'] = (cam1.fov_distance(), cam2.fov_distance())
 
-    Xs = _smoothstep(np.linspace(0.0, 1.0, frames_between_cameras))
+    Xs = _smoothstep(np.linspace(0.0, 1.0, frames_between_cameras), N=N)
     x = Xs[timestep % frames_between_cameras]
 
     eye = eye_1 * (1 - x) + eye_2 * x
     target = target_1 * (1 - x) + target_2 * x
     up = up_1 * (1 - x) + up_2 * x
-    width = width_1 * (1 - x) + width_2 * x
-    height = height_1 * (1 - x) + height_2 * x
+    width = round(width_1 * (1 - x) + width_2 * x)
+    height = round(height_1 * (1 - x) + height_2 * x)
     intrinsics = {intr_name: intr_val[0] * (1 - x) + intr_val[1] * x for intr_name, intr_val in intrinsics.items()}
 
     cam = Camera.from_args(
         eye=eye,
-        at=target,
+        at=eye - target,
         up=up,
         width=width, height=height,
         device=cam1.device,
@@ -194,8 +196,8 @@ def interpolate_camera_on_spline_path(
     eye = _catmull_rom(t, eye_1, eye_2, eye_3, eye_4)
     target = _catmull_rom(t, target_1, target_2, target_3, target_4)
     up = _catmull_rom(t, up_1, up_2, up_3, up_4)
-    width = _catmull_rom(t, width_1, width_2, width_3, width_4)
-    height = _catmull_rom(t, height_1, height_2, height_3, height_4)
+    width = round(_catmull_rom(t, width_1, width_2, width_3, width_4))
+    height = round(_catmull_rom(t, height_1, height_2, height_3, height_4))
     intrinsics = {intr_name: _catmull_rom(t, intr_val[0], intr_val[1], intr_val[2], intr_val[3])
                   for intr_name, intr_val in intrinsics.items()}
 
@@ -211,9 +213,10 @@ def interpolate_camera_on_spline_path(
     return cam
 
 
-def smooth_cyclic_camera_path_generator(
+def infinite_loop_camera_path_generator(
     trajectory: List[Camera],
-    frames_between_cameras: int = 60
+    frames_between_cameras: int = 60,
+    interpolation: str = 'polynomial',
 ):
     r"""A generator function for returning continuous camera objects an o smoothed path interpolated
     from a trajectory of cameras.
@@ -225,20 +228,32 @@ def smooth_cyclic_camera_path_generator(
         trajectory (List[kaolin.render.camera.Camera]): A trajectory of camera nodes, used to form a continuous path.
         frames_between_cameras (int): Number of interpolated points generated between each pair of cameras on the
             trajectory. In essence, this value controls how detailed, or smooth the path is.
+        interpolation (str): Type of interpolation function used:
+            'polynomial' uses a smoothstep polynomial function which tends to overshoot around the keyframes.
+                This interpolator is fitting for paths orbiting an object of interest.
+            'catmull_rom' uses a spline defined by 4 control points, guaranteed to pass precisely through the keyframes.
 
     Returns:
         (kaolin.render.camera.Camera):
             An interpolated camera object formed by the cameras trajectory.
     """
+    if interpolation == 'polynomial':
+        interpolator =  interpolate_camera_on_polynomial_path
+    elif interpolation == 'catmull_rom':
+        interpolator =  interpolate_camera_on_spline_path
+    else:
+        raise ValueError("Unknown interpolation function specified. Valid options: 'polynomial', 'catmull_rom'.")
+
     timestep = 0
     while True:
-        yield interpolate_camera_on_polynomial_path(trajectory, timestep, frames_between_cameras)
+        yield interpolator(trajectory, timestep, frames_between_cameras)
         timestep += 1
 
 
-def linear_camera_path_generator(
+def camera_path_generator(
     trajectory: List[Camera],
-    frames_between_cameras: int = 60
+    frames_between_cameras: int = 60,
+    interpolation: str = 'catmull_rom'
 ):
     r"""A generator function for returning continuous camera objects an o path interpolated on a spline
     from a trajectory of cameras.
@@ -249,17 +264,29 @@ def linear_camera_path_generator(
         trajectory (List[kaolin.render.camera.Camera]): A trajectory of camera nodes, used to form a continuous path.
         frames_between_cameras (int): Number of interpolated points generated between each pair of cameras on the
             trajectory. In essence, this value controls how detailed, or smooth the path is.
+        interpolation (str): Type of interpolation function used:
+            'polynomial' uses a smoothstep polynomial function which tends to overshoot around the keyframes.
+                This interpolator is fitting for paths orbiting an object of interest.
+            'catmull_rom' uses a spline defined by 4 control points, guaranteed to pass precisely through the keyframes.
 
     Returns:
         (kaolin.render.camera.Camera):
             An interpolated camera object formed by the cameras trajectory.
     """
-    _trajectory = trajectory + [trajectory[-1]]
-    timestep = 0
+    if interpolation == 'polynomial':
+        interpolator =  interpolate_camera_on_polynomial_path
+    elif interpolation == 'catmull_rom':
+        interpolator =  interpolate_camera_on_spline_path
+    else:
+        raise ValueError("Unknown interpolation function specified. Valid options: 'polynomial', 'catmull_rom'.")
+
+    _trajectory = [trajectory[0]] + trajectory + [trajectory[-1], trajectory[-1]]
+    timestep = frames_between_cameras
+
     while True:
-        yield interpolate_camera_on_spline_path(_trajectory, timestep, frames_between_cameras)
+        yield interpolator(_trajectory, timestep, frames_between_cameras)
         timestep += 1
 
         traj_idx = (timestep // frames_between_cameras) % len(_trajectory)
-        if traj_idx == len(_trajectory) - 2:
+        if traj_idx == len(_trajectory) - 3:
             break

--- a/playground/utils/kaolin_future/transform.py
+++ b/playground/utils/kaolin_future/transform.py
@@ -1,0 +1,413 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+from typing import Union
+
+import numpy as np
+import torch
+
+
+"""
+This module is to be included in next version of kaolin 0.18.0.
+As of March 26, 2025 the latest public release is kaolin 0.17.0, hence it's included here independently.
+"""
+
+PI = torch.pi if hasattr(torch, 'pi') else np.pi  # Fallback for older torch versions
+
+
+class ObjectTransform:
+    """ObjectTransform represents the local transformations that convert the object from local space coordinates
+    to world coordinates.
+    """
+
+    def __init__(self, device=None, dtype=None):
+        self.device: torch.device = device
+        self.dtype: torch.dtype = dtype
+
+        self._translation = torch.zeros(3, device=self.device, dtype=self.dtype)
+        self._rotation = torch.zeros(3, device=self.device, dtype=self.dtype)
+        self._scale = torch.ones(4, device=self.device, dtype=self.dtype)
+        self._permutation = torch.eye(4, device=self.device, dtype=self.dtype)
+
+    def reset(self):
+        """ Restore object transform to unit scale, at the origin, with zero orientation. """
+        self._translation = torch.zeros(3, device=self.device, dtype=self.dtype)
+        self._rotation = torch.zeros(3, device=self.device, dtype=self.dtype)
+        self._scale = torch.ones(4, device=self.device, dtype=self.dtype)
+        self._permutation = torch.eye(4, device=self.device, dtype=self.dtype)
+
+    def translate(self, translation: torch.Tensor):
+        """
+        Args:
+            translation (torch.Tensor):
+                Amount of translation in world space coordinates, as a (3,) shaped tensor
+        """
+        self._translation += translation
+
+    def rotate(self, rotation: torch.Tensor):
+        """
+        Args:
+            rotation (torch.Tensor):
+                Amount of rotation as euler angles, as a (3,) shaped tensor
+        """
+        self._rotation += rotation
+
+    def scale(self, scale: Union[float, torch.Tensor]):
+        """
+        Args:
+            scale (float or torch.Tensor):
+                Amount of scale in world space coordinates.
+                For non uniform scale, pass a (3,) shaped tensor.
+                For uniform scale, pass a float.
+        """
+        self._scale[:3] *= scale
+
+    def permute(self, permutation):
+        """
+        Args:
+            permutation (list[int]): The permutation of the axis.
+                                     For example, [1, 0, 2] will swap the x and y axis.
+        """
+        permutation = torch.tensor(permutation, device=self.device, dtype=torch.long)
+        if permutation.shape[0] != 3:
+            raise Exception("Permutation only supports 3 axis.")
+        if torch.any(permutation < 0):
+            raise Exception("Permutation axis cannot be negative.")
+        if torch.any(permutation > 2):
+            raise Exception("Permutation axis out of bounds.")
+        self._permutation.fill_(0)
+        self._permutation[(0,1,2), permutation] = 1
+        self._permutation[3, 3] = 1
+
+    def _translation_mat(self, t: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            t (torch.Tensor): The translation component of the transform
+        Returns:
+            (torch.Tensor): a 4x4 matrix which represents the translation component of the transform
+        """
+        mat = torch.eye(4, device=self.device, dtype=self.dtype)
+        mat[:3, -1] = t
+        return mat
+
+    def _rotation_mat_x(self, angle: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            angle (torch.Tensor): The x axis euler angle component of the transform, in radians
+        Returns:
+            (torch.Tensor): a 4x4 matrix which represents the rotation x component of the transform
+        """
+        mat = torch.eye(4, device=self.device, dtype=self.dtype)
+        mat[1, 1] = torch.cos(angle)
+        mat[1, 2] = torch.sin(angle)
+        mat[2, 1] = -torch.sin(angle)
+        mat[2, 2] = torch.cos(angle)
+        return mat
+
+    def _rotation_mat_y(self, angle: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            angle (torch.Tensor): The y axis euler angle component of the transform, in radians
+        Returns:
+            (torch.Tensor): a 4x4 matrix which represents the rotation y component of the transform
+        """
+        mat = torch.eye(4, device=self.device, dtype=self.dtype)
+        mat[0, 0] = torch.cos(angle)
+        mat[0, 2] = -torch.sin(angle)
+        mat[2, 0] = torch.sin(angle)
+        mat[2, 2] = torch.cos(angle)
+        return mat
+
+    def _rotation_mat_z(self, angle: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            angle (torch.Tensor): The z axis euler angle component of the transform, in radians
+        Returns:
+            (torch.Tensor): a 4x4 matrix which represents the rotation z component of the transform
+        """
+        mat = torch.eye(4, device=self.device, dtype=self.dtype)
+        mat[0, 0] = torch.cos(angle)
+        mat[0, 1] = -torch.sin(angle)
+        mat[1, 0] = torch.sin(angle)
+        mat[1, 1] = torch.cos(angle)
+        return mat
+
+    def _rotation_mat(self, rx, ry, rz) -> torch.Tensor:
+        """
+        Args:
+            rx (torch.Tensor): The x axis euler angle component of the transform, in radians
+            ry (torch.Tensor): The y axis euler angle component of the transform, in radians
+            rz (torch.Tensor): The z axis euler angle component of the transform, in radians
+        Returns:
+            (torch.Tensor): a 4x4 matrix which represents the complete rotation component of the transform
+        """
+        Rx = self._rotation_mat_x(rx)
+        Ry = self._rotation_mat_y(ry)
+        Rz = self._rotation_mat_z(rz)
+        return Rz @ Ry @ Rx
+
+    def _scale_mat(self, s: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            s (torch.Tensor): The scale component of the transform
+        Returns:
+            (torch.Tensor): a 4x4 matrix which represents the scale component of the transform
+        """
+        return torch.diag(s).to(device=self.device, dtype=self.dtype)
+
+    def _inv_translation_mat(self, t: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            t (torch.Tensor): The translation component of the transform
+        Returns:
+            (torch.Tensor): a 4x4 matrix which represents the inverse translation component of the transform
+        """
+        mat = torch.eye(4, device=self.device, dtype=self.dtype)
+        mat[:3, -1] = -t
+        return mat
+
+    def _inv_rotation_mat(self, rx, ry, rz) -> torch.Tensor:
+        """
+        Args:
+            rx (torch.Tensor): The x axis euler angle component of the transform, in radians
+            ry (torch.Tensor): The y axis euler angle component of the transform, in radians
+            rz (torch.Tensor): The z axis euler angle component of the transform, in radians
+        Returns:
+            (torch.Tensor): a 4x4 matrix which represents the complete inverse rotation component of the transform
+        """
+        Rx = self._rotation_mat_x(-rx)
+        Ry = self._rotation_mat_y(-ry)
+        Rz = self._rotation_mat_z(-rz)
+        return Rx @ Ry @ Rz
+
+    def _inv_scale_mat(self, s: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            s (torch.Tensor): The scale component of the transform
+        Returns:
+            (torch.Tensor): a 4x4 matrix which represents the inverse scale component of the transform
+        """
+        return torch.diag(1.0 / s).to(device=self.device, dtype=self.dtype)
+
+    def model_matrix(self):
+        """
+        Returns:
+            (torch.Tensor): a 4x4 model matrix which encodes the complete transform of the object from local
+            coordinates to world coordinates.
+        """
+        # Transformations applied in order of
+        # Translation @ Rotation @ Scale
+        scale_mat = self._scale_mat(self._scale)
+        rotation_rads = self._rotation.div(180.0).mul(PI)
+        rotation_mat = self._rotation_mat(*rotation_rads)
+        translation_mat = self._translation_mat(self._translation)
+        model_mat = translation_mat @ rotation_mat @ scale_mat @ self._permutation
+        return model_mat
+
+    def inv_model_matrix(self):
+        """
+        Returns:
+            (torch.Tensor): a 4x4 model matrix which encodes the complete transform of the object from world
+            coordinates to local coordinates.
+            This version can be useful, for example, for ray traced pipelines (where the rays are inverse transformed,
+            rather than the object).
+        """
+        # Transformations applied in order of
+        # Scale^(-1) @ Rotation^(-1) @ Translation^(-1)
+        scale_mat = self._inv_scale_mat(self._scale)
+        rotation_rads = self._rotation.div(180.0).mul(PI)
+        rotation_mat = self._inv_rotation_mat(*rotation_rads)
+        translation_mat = self._inv_translation_mat(self._translation)
+        inv_mat = self._permutation @ scale_mat @ rotation_mat @ translation_mat
+        return inv_mat
+
+    def rotation_matrix(self):
+        rotation_rads = self._rotation.div(180.0).mul(PI)
+        rotation_mat = self._rotation_mat(*rotation_rads)
+        return rotation_mat @ self._permutation
+
+    def inv_rotation_matrix(self):
+        rotation_rads = self._rotation.div(180.0).mul(PI)
+        rotation_mat = self._inv_rotation_mat(*rotation_rads)
+        return self._permutation @ rotation_mat
+
+    def to(self, *args, **kwargs) -> ObjectTransform:
+        """ Shifts the transform to a different device / dtype.
+        seealso::func:`torch.Tensor.to` for an elaborate explanation of using this method.
+
+        Returns:
+            The object transform tensors will be ast to a different device / dtype
+        """
+        _translation = self._translation.to(*args, **kwargs)
+        _rotation = self._rotation.to(*args, **kwargs)
+        _scale = self._scale.to(*args, **kwargs)
+        _permutation = self._permutation.to(*args, **kwargs)
+        if _translation is not self._translation or \
+           _rotation is not self._rotation or \
+           _scale is not self._scale or \
+           _permutation is not self._permutation:
+            transform = ObjectTransform(device=_translation.device, dtype=_translation.dtype)
+            transform._translation = _translation
+            transform._rotation = _rotation
+            transform._scale = _scale
+            transform._permutation = _permutation
+            return transform
+        else:
+            return self
+
+    @property
+    def tx(self):
+        """
+        Returns:
+            The x-axis translation component tensor.
+        """
+        return self._translation[0]
+
+    @tx.setter
+    def tx(self, value):
+        """ Sets the x-axis translation component tensor.
+        Args:
+            value: New translation-x value to set
+        """
+        self._translation[0] = value
+
+    @property
+    def ty(self):
+        """
+        Returns:
+            The y-axis translation component tensor, shaped as (tx, ty, tz).
+        """
+        return self._translation[1]
+
+    @ty.setter
+    def ty(self, value):
+        """ Sets the y-axis translation component tensor.
+        Args:
+            value: New translation-y value to set
+        """
+        self._translation[1] = value
+
+    @property
+    def tz(self):
+        """
+        Returns:
+            The z-axis translation component tensor, shaped as (tx, ty, tz).
+        """
+        return self._translation[2]
+
+    @tz.setter
+    def tz(self, value):
+        """ Sets the z-axis translation component tensor.
+        Args:
+            value: New translation-z value to set
+        """
+        self._translation[2] = value
+
+    @property
+    def rx(self):
+        """
+        Returns:
+            The euler angle of the rotation component around the x axis, in degrees
+        """
+        return self._rotation[0]
+
+    @rx.setter
+    def rx(self, value):
+        """ Sets the euler angle of the rotation component around the x axis
+        Args:
+            value: New angle-x value to set, in degrees
+        """
+        self._rotation[0] = value
+
+    @property
+    def ry(self):
+        """
+        Returns:
+            The euler angle of the rotation component around the y axis, in degrees
+        """
+        return self._rotation[1]
+
+    @ry.setter
+    def ry(self, value):
+        """ Sets the euler angle of the rotation component around the y axis
+        Args:
+            value: New angle-y value to set, in degrees
+        """
+        self._rotation[1] = value
+
+    @property
+    def rz(self):
+        """
+        Returns:
+            The euler angle of the rotation component around the z axis, in degrees
+        """
+        return self._rotation[2]
+
+    @rz.setter
+    def rz(self, value):
+        """ Sets the euler angle of the rotation component around the z axis
+        Args:
+            value: New angle-z value to set, in degrees
+        """
+        self._rotation[2] = value
+
+    @property
+    def sx(self):
+        """
+        Returns:
+            The scale component for the x axis.
+        """
+        return self._scale[0]
+
+    @sx.setter
+    def sx(self, value):
+        """ Sets the x-axis scale component tensor.
+        Args:
+            value: New scale-x value to set
+        """
+        self._scale[0] = value
+
+    @property
+    def sy(self):
+        """
+        Returns:
+            The scale component for the y axis.
+        """
+        return self._scale[1]
+
+    @sy.setter
+    def sy(self, value):
+        """ Sets the y-axis scale component tensor.
+        Args:
+            value: New scale-y value to set
+        """
+        self._scale[1] = value
+
+    @property
+    def sz(self):
+        """
+        Returns:
+            The scale component for the z axis.
+        """
+        return self._scale[2]
+
+    @sz.setter
+    def sz(self, value):
+        """ Sets the z-axis scale component tensor.
+        Args:
+            value: New scale-z value to set
+        """
+        self._scale[2] = value

--- a/playground/utils/video_out.py
+++ b/playground/utils/video_out.py
@@ -36,13 +36,13 @@ from playground.utils.kaolin_future.interpolated_cameras import camera_path_gene
 class VideoRecorder:
     """ A module for saving video footage of camera trajectories within the Playground"""
 
-    MODES = ['linear_smooth', 'linear_spline', 'continuous', 'depth_of_field']
+    MODES = ['path_smooth', 'path_spline', 'cyclic', 'depth_of_field']
 
     def __init__(self,
         renderer,
         trajectory_output_path="output.mp4",
         cameras_save_path="cameras.npy",
-        mode='linear_smooth',
+        mode='path_smooth',
         frames_between_cameras=60,
         video_fps=30,
         min_dof=2.5,
@@ -55,9 +55,9 @@ class VideoRecorder:
             trajectory_output_path (str): Output path for saved video
             cameras_save_path (str): Save path for storing and loading camera trajectories.
             mode (str): Determines how keyframes are interpolated:
-                'linear_smooth' - shifts the camera in a linear path along the trajectory, using smoothstep interpolation
-                'linear_spline' - shifts the camera in a linear path along the trajectory, using catmull-rom splines
-                'continuous' - shifts the camera in a cyclic trajectory, determined by fitting a bspline
+                'path_smooth' - shifts the camera in a path along the trajectory, using smoothstep interpolation
+                'path_spline' - shifts the camera in a path along the trajectory, using catmull-rom splines
+                'cyclic' - shifts the camera in a cyclic trajectory, determined by fitting a bspline
                 'depth_of_field' - interpolates the depth of field over a static frame (first frame in trajectory)
             frames_between_cameras (int): How many cameras are inserted between keyframe cameras in the trajectory
             video_fps (int): FPS of exported video
@@ -125,9 +125,9 @@ class VideoRecorder:
 
     def render_linear_trajectory(self, interpolation_mode='polynomial'):
         if len(self.trajectory) < 2:
-            raise ValueError('Rendering a linear trajectory requires at least 2 cameras.')
+            raise ValueError('Rendering a path trajectory requires at least 2 cameras.')
         elif interpolation_mode == 'catmull_rom' and len(self.trajectory) < 4:
-            raise ValueError('Rendering a linear spline trajectory requires at least 4 cameras.')
+            raise ValueError('Rendering a path with a spline interpolated trajectory requires at least 4 cameras.')
 
         out_video = None
         interpolated_path = camera_path_generator(
@@ -206,11 +206,11 @@ class VideoRecorder:
         """
         if self.mode == 'depth_of_field':
             self.render_dof_trajectory()
-        elif self.mode == 'continuous':
+        elif self.mode == 'cyclic':
             self.render_continuous_trajectory()
-        elif self.mode == 'linear_smooth':
+        elif self.mode == 'path_smooth':
             self.render_linear_trajectory('polynomial')
-        elif self.mode == 'linear_spline':
+        elif self.mode == 'path_spline':
             self.render_linear_trajectory('catmull_rom')
         else:
             raise ValueError(f'Unknown mode: {self.mode}')

--- a/playground/utils/video_out.py
+++ b/playground/utils/video_out.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+import numpy as np
+import torch
+import cv2
+from tqdm import tqdm
+from scipy.interpolate import splprep, splev
+from kaolin.render.camera import Camera
+from threedgrut.utils.logger import logger
+from threedgrut.model.model import MixtureOfGaussians
+from threedgrut.model.background import BackgroundColor
+from playground.utils.mesh_io import load_mesh, load_materials, load_missing_material_info, create_procedural_mesh
+from playground.utils.depth_of_field import DepthOfField
+from playground.utils.spp import SPP
+from playground.tracer import Tracer
+from playground.utils.kaolin_future.transform import ObjectTransform
+from playground.utils.kaolin_future.conversions import polyscope_from_kaolin_camera, polyscope_to_kaolin_camera
+from playground.utils.kaolin_future.fisheye import generate_fisheye_rays
+from playground.utils.kaolin_future.interpolated_cameras import camera_path_generator
+
+
+class VideoRecorder:
+    """ A module for saving video footage of camera trajectories within the Playground"""
+
+    MODES = ['linear_smooth', 'linear_spline', 'continuous', 'depth_of_field']
+
+    def __init__(self,
+        renderer,
+        trajectory_output_path="output.mp4",
+        cameras_save_path="cameras.npy",
+        mode='linear_smooth',
+        frames_between_cameras=60,
+        video_fps=30,
+        min_dof=2.5,
+        max_dof=24
+    ):
+        """
+        Creates a video recorder for saving camera animation along trajectories.
+        Args:
+            renderer: Reference to the Playground rendering engine, interfaced through a 'render()' function.
+            trajectory_output_path (str): Output path for saved video
+            cameras_save_path (str): Save path for storing and loading camera trajectories.
+            mode (str): Determines how keyframes are interpolated:
+                'linear_smooth' - shifts the camera in a linear path along the trajectory, using smoothstep interpolation
+                'linear_spline' - shifts the camera in a linear path along the trajectory, using catmull-rom splines
+                'continuous' - shifts the camera in a cyclic trajectory, determined by fitting a bspline
+                'depth_of_field' - interpolates the depth of field over a static frame (first frame in trajectory)
+            frames_between_cameras (int): How many cameras are inserted between keyframe cameras in the trajectory
+            video_fps (int): FPS of exported video
+            min_dof (float): For 'depth_of_field' mode only, determines the minimum dof for interpolation start / end
+            max_dof (float): For 'depth_of_field' mode only, determines the maximum dof for interpolation start / end
+        """
+        self.renderer = renderer
+
+        # List of kaolin.render.camera.Camera objects forming the trajectory
+        self.trajectory = []
+
+        # Selected interpolation modes
+        self.mode = mode
+
+        # Output path for generated video file
+        self.trajectory_output_path = trajectory_output_path
+
+        # For saving and loading trajectory paths
+        self.cameras_save_path = cameras_save_path
+
+        # Camera FPS -- how many cameras are interpolated between key views
+        self.frames_between_cameras = frames_between_cameras
+
+        # Saved Video FPS
+        self.video_fps = video_fps
+
+        # For depth-of-field interpolation mode only - determines the boundary
+        self.min_dof = min_dof
+        self.max_dof = max_dof
+
+    def add_camera(self, camera: Camera):
+        self.trajectory.append(camera)
+
+    def reset_trajectory(self):
+        self.trajectory = []
+
+    def save_trajectory(self):
+        torch.save(self.trajectory, self.cameras_save_path)
+
+    def load_trajectory(self):
+        self.trajectory = torch.load(self.cameras_save_path)
+
+    def render_dof_trajectory(self):
+        out_video = None
+        old_use_dof = self.renderer.use_depth_of_field
+        old_focus_z = self.renderer.depth_of_field.focus_z
+        try:
+            camera = self.trajectory[0]
+            dofs = np.linspace(self.min_dof, self.max_dof, self.frames_between_cameras)
+            for dof in tqdm(dofs):
+                self.renderer.use_depth_of_field = True
+                self.renderer.depth_of_field.focus_z = dof
+                rgb = self.renderer.render(camera)['rgb']
+
+                if out_video is None:
+                    out_video = cv2.VideoWriter(self.trajectory_output_path, cv2.VideoWriter_fourcc(*'mp4v'),
+                                                self.video_fps, (rgb.shape[2], rgb.shape[1]), True)
+                data = rgb[0].clip(0, 1).detach().cpu().numpy()
+                data = (data * 255).astype(np.uint8)
+                data = cv2.cvtColor(data, cv2.COLOR_BGR2RGB)
+                out_video.write(data)
+        finally:
+            self.renderer.use_depth_of_field = old_use_dof
+            self.renderer.depth_of_field.focus_z = old_focus_z
+
+    def render_linear_trajectory(self, interpolation_mode='polynomial'):
+        if len(self.trajectory) < 2:
+            raise ValueError('Rendering a linear trajectory requires at least 2 cameras.')
+        elif interpolation_mode == 'catmull_rom' and len(self.trajectory) < 4:
+            raise ValueError('Rendering a linear spline trajectory requires at least 4 cameras.')
+
+        out_video = None
+        interpolated_path = camera_path_generator(
+            trajectory=self.trajectory,
+            frames_between_cameras=self.frames_between_cameras,
+            interpolation=interpolation_mode
+        )
+
+        for camera in tqdm(interpolated_path):
+            rgb = self.renderer.render(camera)['rgb']
+
+            if out_video is None:
+                out_video = cv2.VideoWriter(self.trajectory_output_path, cv2.VideoWriter_fourcc(*'mp4v'),
+                                            self.video_fps, (rgb.shape[2], rgb.shape[1]), True)
+            data = rgb[0].clip(0, 1).detach().cpu().numpy()
+            data = (data * 255).astype(np.uint8)
+            data = cv2.cvtColor(data, cv2.COLOR_BGR2RGB)
+            out_video.write(data)
+        out_video.release()
+
+    def render_continuous_trajectory(self):
+        if len(self.trajectory) < 4:
+            raise ValueError('Rendering a continuous trajectory requires at least 4 cameras.')
+
+        def _fit_bspline(data_points, frames_between_cameras):
+            stacked_data_points = torch.stack([dp for dp in data_points], dim=1).cpu().numpy()
+            tck, u = splprep(stacked_data_points, u=None, s=0.0, per=1)
+            u_new = np.linspace(u.min(), u.max(), frames_between_cameras * len(data_points))
+            interpolated_cam_param = np.stack(splev(u_new, tck, der=0)).T
+            interpolated_cam_param = torch.tensor(interpolated_cam_param)
+            return interpolated_cam_param
+
+        cam_poses = _fit_bspline(
+            data_points=[c.cam_pos().squeeze() for c in self.trajectory],
+            frames_between_cameras=self.frames_between_cameras
+        )
+        cam_ats = _fit_bspline(
+            data_points=[c.cam_pos().squeeze() - c.cam_forward().squeeze() for c in self.trajectory],
+            frames_between_cameras=self.frames_between_cameras
+        )
+        cam_ups = _fit_bspline(
+            data_points=[c.cam_up().squeeze() for c in self.trajectory],
+            frames_between_cameras=self.frames_between_cameras
+        )
+
+        first_cam = self.trajectory[0]
+        interpolated_path = []
+        for eye, at, up in tqdm(zip(cam_poses, cam_ats, cam_ups)):
+            interpolated_path.append(
+                Camera.from_args(
+                    eye=eye,
+                    at=at,
+                    up=up,
+                    fov=first_cam.fov(in_degrees=False),
+                    width=first_cam.width, height=first_cam.height,
+                    device=first_cam.device
+                )
+            )
+
+        out_video = None
+        for camera in tqdm(interpolated_path):
+            rgb = self.renderer.render(camera)['rgb']
+
+            if out_video is None:
+                out_video = cv2.VideoWriter(self.trajectory_output_path, cv2.VideoWriter_fourcc(*'mp4v'),
+                                            self.video_fps, (rgb.shape[2], rgb.shape[1]), True)
+            data = rgb[0].clip(0, 1).detach().cpu().numpy()
+            data = (data * 255).astype(np.uint8)
+            data = cv2.cvtColor(data, cv2.COLOR_BGR2RGB)
+            out_video.write(data)
+        out_video.release()
+
+    def render_video(self):
+        """
+        Renders the trajectory to a video file, according to the set mode (see init()).
+        """
+        if self.mode == 'depth_of_field':
+            self.render_dof_trajectory()
+        elif self.mode == 'continuous':
+            self.render_continuous_trajectory()
+        elif self.mode == 'linear_smooth':
+            self.render_linear_trajectory('polynomial')
+        elif self.mode == 'linear_spline':
+            self.render_linear_trajectory('catmull_rom')
+        else:
+            raise ValueError(f'Unknown mode: {self.mode}')


### PR DESCRIPTION
This MR is a preparation for the eventual headless mode of the playground. The motivation is to allow additional viewers where polyscope cannot be installed, as well as easier integration within other projects.

The `utils/kaolin_future` includes logic that will high probability be relocated to the next version of kaolin (v18.0).

1. `Playground` now assumes kaolin's [Cameras](https://github.com/NVIDIAGameWorks/kaolin/tree/master/examples/recipes/camera), instead of the gui-coupled `ViewParams` from polyscope. e.g. rendering is now invoked as `render(self, camera: Camera)`. kaolin and polyscope cameras can be converted back and forth, see `utils/kaolin_future/conversions.py`.
2. Playground rendering is offered in 2 ways: online (`render_pass()` - which is more interactive) and offline (`render()` - which calls all rendering passes needed for a single frame for high quality image), see `playground.py`.
3. **raygen**: functionality now uses Kaolin's raygen for pinhole rays. The raygen functionality for fisheye have been adapted to kaolin, see see `utils/kaolin_future/fisheye.py`.
4. **`VideoRecorder`** is extracted from `Playground` class to reduce the size of this monolith. All camera interpolations now use kaolin's new camera interpolation module, see `utils/kaolin_future/interpolated_cameras.py`.

For video recording, the gui have been slightly simplified by reducing the `use_dof` and `continuous` checkboxes to a combo box with the following options:

- mode (str): Determines how keyframes are interpolated:
  - 'linear_smooth' - shifts the camera in a linear path along the trajectory, using smoothstep interpolation (in main, this is _not use_dof and not continuous_)
  - 'linear_spline' - shifts the camera in a linear path along the trajectory, using catmull-rom splines (new mode)
  - 'continuous' - shifts the camera in a cyclic trajectory, determined by fitting a bspline (in main, this is _not use_dof and continuous_)
  - 'depth_of_field' - interpolates the depth of field over a static frame (first frame in trajectory) (in main, this is _use_dof_)