### PR TITLE
fix alpha & depth map, enable hit count

### DIFF
--- a/threedgut_tracer/include/3dgut/kernels/cuda/common/rayPayloadBackward.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/common/rayPayloadBackward.cuh
@@ -41,7 +41,6 @@ __device__ __inline__ RayPayloadT initializeBackwardRay(const threedgut::RenderP
     RayPayloadT ray = initializeRay<RayPayloadT>(params,
                                                  sensorRayOriginPtr,
                                                  sensorRayDirectionPtr,
-                                                 worldHitDistancePtr,
                                                  sensorToWorldTransform);
 
     if (ray.isAlive()) {

--- a/threedgut_tracer/include/3dgut/kernels/cuda/models/shGaussianModel.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/models/shGaussianModel.cuh
@@ -22,24 +22,24 @@ struct ShGaussian {
 
     using Particles = TParticles;
 
-    template <typename TRay>
-    static inline __device__ void eval(const threedgut::RenderParameters& params,
-                                       TRay& ray,
-                                       threedgut::MemoryHandles parameters) {
-        if (ray.isValid()) {
+    // template <typename TRay>
+    // static inline __device__ void eval(const threedgut::RenderParameters& params,
+    //                                    TRay& ray,
+    //                                    threedgut::MemoryHandles parameters) {
+    //     if (ray.isValid()) {
+    // 
+    //         // mark the ray as front hit if the traversed volume is sufficiently opaque
+    //         if (ray.transmittance < params.hitTransmittance) {
+    //             ray.hitFront();
+    //         }
+    //     }
+    // }
 
-            // mark the ray as front hit if the traversed volume is sufficiently opaque
-            if (ray.transmittance < params.hitTransmittance) {
-                ray.hitFront();
-            }
-        }
-    }
-
-    template <typename TRay>
-    static inline __device__ void evalBackward(const threedgut::RenderParameters& params,
-                                               TRay& ray,
-                                               threedgut::MemoryHandles parameters,
-                                               threedgut::MemoryHandles parametersGradient) {
-        // NOOP
-    }
+    // template <typename TRay>
+    // static inline __device__ void evalBackward(const threedgut::RenderParameters& params,
+    //                                            TRay& ray,
+    //                                            threedgut::MemoryHandles parameters,
+    //                                            threedgut::MemoryHandles parametersGradient) {
+    //     // NOOP
+    // }
 };

--- a/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutKBufferRenderer.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutKBufferRenderer.cuh
@@ -160,6 +160,8 @@ struct GUTKBufferRenderer : Params {
             particles.featureIntegrateFwd(hitWeight,
                                           Params::PerRayParticleFeatures ? particles.featuresFromBuffer(hitParticle.idx, ray.direction) : tcnn::max(particleFeatures[hitParticle.idx], 0.f),
                                           ray.features);
+
+            if (hitWeight > 0.0f) ray.countHit();
         }
 
         if (ray.transmittance < Particles::MinTransmittanceThreshold) {
@@ -274,8 +276,6 @@ struct GUTKBufferRenderer : Params {
                                            particleFeaturesGradientBuffer);
                     }
                     hitParticleKBuffer.insert(hitParticle);
-
-                    ray.countHit();
                 }
             }
         }
@@ -381,8 +381,6 @@ struct GUTKBufferRenderer : Params {
                                                                   particleFeaturesGradientBuffer, tileThreadIdx);
                 }
                 particles.processHitBwdUpdateDensityGradient(particleData.idx, densityRawParametersGrad, tileThreadIdx);
-         
-                // ray.countHit(); // NOTE: Hit count is not differentiable
             }
         }
     }

--- a/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutKBufferRenderer.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutKBufferRenderer.cuh
@@ -274,6 +274,8 @@ struct GUTKBufferRenderer : Params {
                                            particleFeaturesGradientBuffer);
                     }
                     hitParticleKBuffer.insert(hitParticle);
+
+                    ray.countHit();
                 }
             }
         }
@@ -379,6 +381,8 @@ struct GUTKBufferRenderer : Params {
                                                                   particleFeaturesGradientBuffer, tileThreadIdx);
                 }
                 particles.processHitBwdUpdateDensityGradient(particleData.idx, densityRawParametersGrad, tileThreadIdx);
+         
+                // ray.countHit(); // NOTE: Hit count is not differentiable
             }
         }
     }

--- a/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutRenderer.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutRenderer.cuh
@@ -84,6 +84,7 @@ __global__ void render(threedgut::RenderParameters params,
                        const tcnn::vec3* __restrict__ sensorRayOriginPtr,
                        const tcnn::vec3* __restrict__ sensorRayDirectionPtr,
                        tcnn::mat4x3 sensorToWorldTransform,
+                       float* __restrict__ worldHitCountPtr,
                        float* __restrict__ worldHitDistancePtr,
                        tcnn::vec4* __restrict__ radianceDensityPtr,
                        const tcnn::vec2* __restrict__ particlesProjectedPositionPtr,
@@ -93,7 +94,7 @@ __global__ void render(threedgut::RenderParameters params,
                        const uint64_t* __restrict__ parameterMemoryHandles) {
 
     auto ray = initializeRay<TGUTRenderer::TRayPayload>(
-        params, sensorRayOriginPtr, sensorRayDirectionPtr, worldHitDistancePtr, sensorToWorldTransform);
+        params, sensorRayOriginPtr, sensorRayDirectionPtr, sensorToWorldTransform);
 
     TGUTRenderer::eval(params,
                        ray,
@@ -105,10 +106,10 @@ __global__ void render(threedgut::RenderParameters params,
                        particlesPrecomputedFeaturesPtr,
                        {parameterMemoryHandles});
 
-    TGUTModel::eval(params, ray, {parameterMemoryHandles});
+    // TGUTModel::eval(params, ray, {parameterMemoryHandles});
 
     // NB : finalize ray is not differentiable (has to be no-op when used in a differentiable renderer)
-    finalizeRay(ray, params, sensorRayOriginPtr, worldHitDistancePtr, radianceDensityPtr, sensorToWorldTransform);
+    finalizeRay(ray, params, sensorRayOriginPtr, worldHitCountPtr, worldHitDistancePtr, radianceDensityPtr, sensorToWorldTransform);
 }
 
 __global__ void renderBackward(threedgut::RenderParameters params,
@@ -143,7 +144,7 @@ __global__ void renderBackward(threedgut::RenderParameters params,
                                                                         radianceDensityGradientPtr,
                                                                         sensorToWorldTransform);
 
-    TGUTModel::evalBackward(params, ray, {parameterMemoryHandles}, {parameterGradientMemoryHandles});
+    // TGUTModel::evalBackward(params, ray, {parameterMemoryHandles}, {parameterGradientMemoryHandles});
 
     TGUTBackwardRenderer::eval(params,
                                ray,

--- a/threedgut_tracer/include/3dgut/renderer/gutRenderer.h
+++ b/threedgut_tracer/include/3dgut/renderer/gutRenderer.h
@@ -65,6 +65,7 @@ public:
     Status renderForward(const RenderParameters& params,
                          const tcnn::vec3* sensorRayOriginCudaPtr,
                          const tcnn::vec3* sensorRayDirectionCudaPtr,
+                         float* worldHitCountCudaPtr,
                          float* worldHitDistanceCudaPtr,
                          tcnn::vec4* radianceDensityCudaPtr,
                          Parameters& parameters,

--- a/threedgut_tracer/include/3dgut/splatRaster.h
+++ b/threedgut_tracer/include/3dgut/splatRaster.h
@@ -48,7 +48,7 @@ public:
 
     ~SplatRaster();
 
-    std::tuple<torch::Tensor, torch::Tensor>
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
     trace(uint32_t frameNumber, int numActiveFeatures,
           // Particles
           torch::Tensor particleDensity,

--- a/threedgut_tracer/setup_3dgut.py
+++ b/threedgut_tracer/setup_3dgut.py
@@ -51,6 +51,7 @@ def setup_3dgut(conf):
         f"-DGAUSSIAN_PARTICLE_MIN_ALPHA={conf.render.particle_kernel_min_alpha}",
         f"-DGAUSSIAN_PARTICLE_MAX_ALPHA={conf.render.particle_kernel_max_alpha}",
         f"-DGAUSSIAN_MIN_TRANSMITTANCE_THRESHOLD={conf.render.min_transmittance}",
+        f"-DGAUSSIAN_ENABLE_HIT_COUNT={to_cpp_bool(conf.render.enable_hitcounts)}",
         # Specific to the 3DGUT renderer
         f"-DGAUSSIAN_N_ROLLING_SHUTTER_ITERATIONS={conf.render.splat.n_rolling_shutter_iterations}",
         f"-DGAUSSIAN_K_BUFFER_SIZE={conf.render.splat.k_buffer_size}",

--- a/threedgut_tracer/src/splatRaster.cpp
+++ b/threedgut_tracer/src/splatRaster.cpp
@@ -164,7 +164,7 @@ SplatRaster::SplatRaster(const nlohmann::json& config)
 SplatRaster::~SplatRaster(void) {
 }
 
-std::tuple<torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 SplatRaster::trace(uint32_t frameNumber, int numActiveFeatures,
                    torch::Tensor particleDensity,
                    torch::Tensor particleRadiance,
@@ -189,6 +189,7 @@ SplatRaster::trace(uint32_t frameNumber, int numActiveFeatures,
 
     torch::Tensor rayRadianceDensity = torch::zeros({height, width, 4}, opts);
     torch::Tensor rayHitDistance     = torch::ones({height, width, 1}, opts).multiply(1e06f);
+    torch::Tensor rayHitCount        = torch::zeros({height, width, 1}, opts);
 
     m_parameters.values.numParticles               = numParticles;
     m_parameters.values.radianceSphDegree          = numActiveFeatures;
@@ -218,6 +219,7 @@ SplatRaster::trace(uint32_t frameNumber, int numActiveFeatures,
         renderParameters,
         reinterpret_cast<const tcnn::vec3*>(voidDataPtr(rayOrigin)),
         reinterpret_cast<const tcnn::vec3*>(voidDataPtr(rayDirection)),
+        reinterpret_cast<float*>(voidDataPtr(rayHitCount)),
         reinterpret_cast<float*>(voidDataPtr(rayHitDistance)),
         reinterpret_cast<tcnn::vec4*>(voidDataPtr(rayRadianceDensity)),
         m_parameters,
@@ -230,7 +232,7 @@ SplatRaster::trace(uint32_t frameNumber, int numActiveFeatures,
         timer->stop();
     }
 
-    return std::tuple<torch::Tensor, torch::Tensor>(rayRadianceDensity, rayHitDistance);
+    return std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>(rayRadianceDensity, rayHitDistance, rayHitCount);
 }
 
 std::tuple<torch::Tensor, torch::Tensor>


### PR DESCRIPTION
- alpha map was wrong because of tensor layout was not contiguous
- depth map was not currectly generated due to some deprecated code being used
- added feature to compute hit count for each pixel/ray