### PR TITLE
Switch to loading images on the fly

### DIFF
--- a/threedgrut/datasets/__init__.py
+++ b/threedgrut/datasets/__init__.py
@@ -24,14 +24,12 @@ def make(name: str, config, ray_jitter):
             train_dataset = NeRFDataset(
                 config.path,
                 split="train",
-                return_alphas=False,
                 bg_color=config.model.background.color,
                 ray_jitter=ray_jitter,
             )
             val_dataset = NeRFDataset(
                 config.path,
                 split="val",
-                return_alphas=False,
                 bg_color=config.model.background.color,
             )
         case "colmap":

--- a/threedgrut/datasets/dataset_colmap.py
+++ b/threedgrut/datasets/dataset_colmap.py
@@ -68,8 +68,7 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
         else:
             indices = np.mod(indices, llff_test_split) == 0
         self.poses = self.poses[indices].astype(np.float32)  # poses are numpy arrays
-        self.image_data = self.image_data[indices]  # image_data are UINT8 umpy arrays
-        assert self.image_data.dtype == np.uint8, "Image data must be of type uint8"
+        self.image_data = self.image_data[indices]  # image_data is a str path numpy array
 
         self.camera_centers = self.camera_centers[indices]
         self.center, self.length_scale, self.scene_bbox = self.compute_spatial_extents()
@@ -204,16 +203,14 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
             self.poses.append(C2W)
             cam_centers.append(C2W[:3, 3])
             image_path = os.path.join(self.path, self.get_images_folder(), os.path.basename(extr.name))
-            image_data = np.asarray(Image.open(image_path))
-            assert image_data.dtype == np.uint8, "Image data must be of type uint8"
-            self.image_data.append(image_data)
+            self.image_data.append(image_path)
 
         self.camera_centers = np.array(cam_centers)
         _, diagonal = get_center_and_diag(self.camera_centers)
         self.cameras_extent = diagonal * 1.1
 
         self.poses = np.stack(self.poses)
-        self.image_data = np.stack(self.image_data)
+        self.image_data = np.stack(self.image_data, dtype=str)
 
     @torch.no_grad()
     def compute_spatial_extents(self):
@@ -248,8 +245,11 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
 
     def __getitem__(self, idx) -> dict:
         out_shape = (1, self.image_h, self.image_w, 3)
+        image_data = np.asarray(Image.open(self.image_data[idx]))
+        assert image_data.dtype == np.uint8, "Image data must be of type uint8"
+
         return {
-            "data": torch.tensor(self.image_data[idx]).reshape(out_shape),
+            "data": torch.tensor(image_data).reshape(out_shape),
             "pose": torch.tensor(self.poses[idx]).unsqueeze(0),
             "intr": self.get_intrinsics_idx(idx),
         }
@@ -305,7 +305,10 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
             fov_w = 2.0 * np.arctan(0.5 * w / f_w)
             fov_h = 2.0 * np.arctan(0.5 * h / f_h)
 
-            rgb = self.image_data[i_cam].reshape(h, w, 3) / np.float32(255.0)
+            image_data = np.asarray(Image.open(self.image_data[i_cam]))
+            assert image_data.dtype == np.uint8, "Image data must be of type uint8"
+
+            rgb = image_data.reshape(h, w, 3) / np.float32(255.0)
             assert rgb.dtype == np.float32, "RGB image must be of type float32, but got {}".format(rgb.dtype)
 
             cam_list.append(

--- a/threedgrut/datasets/dataset_colmap.py
+++ b/threedgrut/datasets/dataset_colmap.py
@@ -67,8 +67,8 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
             indices = np.mod(indices, llff_test_split) != 0
         else:
             indices = np.mod(indices, llff_test_split) == 0
-        self.poses = self.poses[indices].astype(np.float32)  # poses are numpy arrays
-        self.image_data = self.image_data[indices]  # image_data is a str path numpy array
+        self.poses = self.poses[indices].astype(np.float32)  # poses is a numpy array
+        self.image_paths = self.image_paths[indices]  # image_paths is a numpy str array of image paths
 
         self.camera_centers = self.camera_centers[indices]
         self.center, self.length_scale, self.scene_bbox = self.compute_spatial_extents()
@@ -189,7 +189,7 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
                 ), f"Colmap camera model '{intr.model}' not handled: Only undistorted datasets (PINHOLE, SIMPLE_PINHOLE or OPENCV_FISHEYE cameras) supported!"
 
         self.poses = []
-        self.image_data = []
+        self.image_paths = []
 
         cam_centers = []
         for extr in logger.track(self.cam_extrinsics, description=f"Load Dataset ({self.split})", color="salmon1"):
@@ -203,14 +203,14 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
             self.poses.append(C2W)
             cam_centers.append(C2W[:3, 3])
             image_path = os.path.join(self.path, self.get_images_folder(), os.path.basename(extr.name))
-            self.image_data.append(image_path)
+            self.image_paths.append(image_path)
 
         self.camera_centers = np.array(cam_centers)
         _, diagonal = get_center_and_diag(self.camera_centers)
         self.cameras_extent = diagonal * 1.1
 
         self.poses = np.stack(self.poses)
-        self.image_data = np.stack(self.image_data, dtype=str)
+        self.image_paths = np.stack(self.image_paths, dtype=str)
 
     @torch.no_grad()
     def compute_spatial_extents(self):
@@ -245,7 +245,7 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
 
     def __getitem__(self, idx) -> dict:
         out_shape = (1, self.image_h, self.image_w, 3)
-        image_data = np.asarray(Image.open(self.image_data[idx]))
+        image_data = np.asarray(Image.open(self.image_paths[idx]))
         assert image_data.dtype == np.uint8, "Image data must be of type uint8"
 
         return {
@@ -305,7 +305,7 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
             fov_w = 2.0 * np.arctan(0.5 * w / f_w)
             fov_h = 2.0 * np.arctan(0.5 * h / f_h)
 
-            image_data = np.asarray(Image.open(self.image_data[i_cam]))
+            image_data = np.asarray(Image.open(self.image_paths[i_cam]))
             assert image_data.dtype == np.uint8, "Image data must be of type uint8"
 
             rgb = image_data.reshape(h, w, 3) / np.float32(255.0)

--- a/threedgrut/datasets/dataset_nerf.py
+++ b/threedgrut/datasets/dataset_nerf.py
@@ -34,11 +34,10 @@ from .utils import create_camera_visualization, get_center_and_diag
 
 
 class NeRFDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
-    def __init__(self, path, device="cuda", split="train", return_alphas=False, ray_jitter=None, bg_color=None):
+    def __init__(self, path, device="cuda", split="train", ray_jitter=None, bg_color=None):
         self.root_dir = path
         self.device = device
         self.split = split
-        self.return_alphas = return_alphas
         self.ray_jitter = ray_jitter
         self.bg_color = bg_color
 
@@ -57,7 +56,6 @@ class NeRFDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
         self.rays_o_cam = torch.zeros((1, self.image_h, self.image_w, 3), dtype=torch.float32, device=self.device)
         self.rays_d_cam = directions.reshape((1, self.image_h, self.image_w, 3)).contiguous()
 
-        assert self.colors.dtype == np.uint8, "RGB image must be of type uint8"
 
     def read_intrinsics(self):
         with open(os.path.join(self.root_dir, "transforms_train.json"), "r") as f:
@@ -92,9 +90,8 @@ class NeRFDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
         self.intrinsics = [fx, fy, w / 2, h / 2]
 
     def read_meta(self, split):
-        self.colors = []
-        self.alphas = []
         self.poses = []
+        self.image_data = []
 
         if split == "trainval":
             with open(os.path.join(self.root_dir, "transforms_train.json"), "r") as f:
@@ -113,13 +110,7 @@ class NeRFDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
             self.poses.append(c2w)
 
             img_path = os.path.join(self.root_dir, f"{frame['file_path']}") + self.suffix
-            if self.return_alphas:
-                img, alpha = NeRFDataset.__read_image(img_path, self.img_wh, return_alpha=True, bg_color=self.bg_color)
-                self.colors.append(img)
-                self.alphas.append(alpha)
-            else:
-                img = NeRFDataset.__read_image(img_path, self.img_wh, return_alpha=False, bg_color=self.bg_color)
-                self.colors.append(img)
+            self.image_data.append(img_path)
 
         self.camera_centers = np.array(cam_centers)
 
@@ -127,12 +118,7 @@ class NeRFDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
         _, diagonal = get_center_and_diag(self.camera_centers)
         self.cameras_extent = diagonal * 1.1
 
-        if len(self.colors) > 0:
-            self.colors = np.stack(self.colors)  # (N_images, H, W, 3)
-
-        if len(self.alphas) > 0 and self.return_alphas:
-            self.alphas = np.stack(self.alphas)  # (N_images, H, W, 1)
-
+        self.image_data = np.stack(self.image_data, dtype=str)
         self.poses = np.array(self.poses).astype(np.float32)  # (N_images, 3, 4)
 
     @torch.no_grad()
@@ -165,8 +151,10 @@ class NeRFDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
 
     def __getitem__(self, idx) -> dict:
         out_shape = (1, self.image_h, self.image_w, 3)
+        img = NeRFDataset.__read_image(self.image_data[idx], self.img_wh, return_alpha=False, bg_color=self.bg_color)
+
         return {
-            "data": torch.tensor(self.colors[idx]).reshape(out_shape),
+            "data": torch.tensor(img).reshape(out_shape),
             "pose": torch.tensor(self.poses[idx]).unsqueeze(0),
         }
 
@@ -226,7 +214,9 @@ class NeRFDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
             fov_w = 2.0 * np.arctan(0.5 * w / f_w)
             fov_h = 2.0 * np.arctan(0.5 * h / f_h)
 
-            rgb = self.colors[i_cam].reshape(h, w, 3) / np.float32(255.0)
+            img = NeRFDataset.__read_image(self.image_data[i_cam], self.img_wh, return_alpha=False, bg_color=self.bg_color)
+            rgb = img.reshape(h, w, 3) / np.float32(255.0)
+
             assert rgb.dtype == np.float32, "RGB image must be of type float32, but got {}".format(rgb.dtype)
 
             cam_list.append(

--- a/threedgrut/render.py
+++ b/threedgrut/render.py
@@ -60,7 +60,7 @@ class Renderer:
         match conf.dataset.type:
             case "nerf":
                 dataset = NeRFDataset(
-                    conf.path, split="test", return_alphas=False, bg_color=conf.model.background.color
+                    conf.path, split="test", bg_color=conf.model.background.color
                 )
             case "colmap":
                 dataset = ColmapDataset(conf.path, split="val", downsample_factor=conf.dataset.downsample_factor)


### PR DESCRIPTION
Currently, we are loading all images to memory before the training. This MR switches the logic to loading on the fly. The has two benefits:
- we might run out of memory in case of large datasets
- it reduces the startup time, which is especially annoying for debugging. 

I quickly ran two runs on my machine (3090) and from this it seems that there is a 20 s slow down (similar to the overhead of loading all the images upfront) but I also measured the pure dataloader speed and that is at around 300 iter/s so it shouldn't actually be the case. Maybe someone else can quickly try it out.

**Loading images on the fly**

Lego:
                 🎊 Training Statistics
┏━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ n_steps ┃ n_epochs ┃ training_time ┃ iteration_speed ┃
┡━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ 30000   │ 300      │ 536.57 s      │ 55.91 it/s      │
└─────────┴──────────┴───────────────┴─────────────────┘

          ⭐ Test Metrics - Step 30000   
┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ mean_psnr ┃ mean_ssim ┃ mean_lpips ┃ std_psnr ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩
│ 36.460    │ 0.984     │ 0.019      │ 3.539    │
└───────────┴───────────┴────────────┴──────────┘

Bonsai:

                 🎊 Training Statistics                 
┏━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ n_steps ┃ n_epochs ┃ training_time ┃ iteration_speed ┃
┡━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ 30000   │ 118      │ 1099.83 s     │ 27.28 it/s      │
└─────────┴──────────┴───────────────┴─────────────────┘

          ⭐ Test Metrics - Step 30000           
┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ mean_psnr ┃ mean_ssim ┃ mean_lpips ┃ std_psnr ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩
│ 32.269    │ 0.942     │ 0.255      │ 2.851    │
└───────────┴───────────┴────────────┴──────────┘

**Current main:**

Lego

                 🎊 Training Statistics
┏━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ n_steps ┃ n_epochs ┃ training_time ┃ iteration_speed ┃
┡━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ 30000   │ 300      │ 520.22 s      │ 57.67 it/s      │
└─────────┴──────────┴───────────────┴─────────────────┘

          ⭐ Test Metrics - Step 30000
┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ mean_psnr ┃ mean_ssim ┃ mean_lpips ┃ std_psnr ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩
│ 36.486    │ 0.984     │ 0.019      │ 3.498    │
└───────────┴───────────┴────────────┴──────────┘

Bonsai:

                 🎊 Training Statistics
┏━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ n_steps ┃ n_epochs ┃ training_time ┃ iteration_speed ┃
┡━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ 30000   │ 118      │ 1079.01 s     │ 27.80 it/s      │
└─────────┴──────────┴───────────────┴─────────────────┘

          ⭐ Test Metrics - Step 30000
┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ mean_psnr ┃ mean_ssim ┃ mean_lpips ┃ std_psnr ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩
│ 32.367    │ 0.942     │ 0.255      │ 2.949    │
└───────────┴───────────┴────────────┴──────────┘


