### PR TITLE
Add support for image masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To mitigate this limitation, we also propose 3DGUT, which enables support for di
 
 
 ## 🔥 News
-- [][2025/04] Support for image masks.
+- ✅[2025/04] Support for image masks.
 - [][2025/04] SparseAdam support.
 - ✅[2025/04] MCMC densification strategy support.
 - ✅[2025/04] Stable release [v1.0.0](https://github.com/nv-tlabs/3dgrut/releases/tag/v1.0.0) tagged.
@@ -41,6 +41,7 @@ To mitigate this limitation, we also propose 3DGUT, which enables support for di
 - [🔧 1 Dependencies and Installation](#-1-dependencies-and-installation)
   - [Running with Docker](#running-with-docker)
 - [💻 2. Train 3DGRT or 3DGUT scenes](#-2-train-3dgrt-or-3dgut-scenes)
+  - [Using image masks](#using-image-masks)
 - [🎥 3. Rendering from Checkpoints](#-3-rendering-from-checkpoints)
   - [To visualize training progress interactively](#to-visualize-training-progress-interactively)
   - [To visualize a pre-trained checkpoint](#to-visualize-a-pre-trained-checkpoint)
@@ -152,6 +153,13 @@ python train.py --config-name apps/colmap_3dgut_mcmc.yaml path=data/mipnerf360/b
 > [!Note]  
 > If you're running from PyCharm IDE, enable rich console through:
 > Run Configuration > Modify Options > Emulate terminal in output console*
+
+### Using image masks
+In order to use image masks, you need to provide a mask for each image in the dataset. The mask is a grayscale image (0s and 1s) that masks out the parts of the image that should not be used during training, i.e. all the pixels with value 0 will be ignored in the loss computation. 
+
+The provided masks should have the same resolution as their corresponding images and be stored in the same folder with the same name but with `_mask.png` extension. For example, to mask out the parts of the image `path-to-image/image.jpeg`, the mask should be stored at `path-to-image/image_mask.png`.
+
+**NOTE**: The masks are only used for loss computation and not for computing the metrics.
 
 ## 🎥 3. Rendering from Checkpoints
 Evaluate Checkpoint with Splatting / OptiX Tracer / Torch

--- a/threedgrut/datasets/protocols.py
+++ b/threedgrut/datasets/protocols.py
@@ -26,6 +26,7 @@ class Batch:
     rays_dir: torch.Tensor  # [B, H, W, 3] ray directions in arbitrary space
     T_to_world: torch.Tensor  # [B, 4, 4] transformation matrix from the ray space to the world space
     rgb_gt: Optional[torch.Tensor] = None
+    mask: Optional[torch.Tensor] = None
     intrinsics: Optional[list] = None
     intrinsics_OpenCVPinholeCameraModelParameters: Optional[dict] = None
     intrinsics_OpenCVFisheyeCameraModelParameters: Optional[dict] = None
@@ -37,11 +38,9 @@ class Batch:
         if self.rgb_gt is not None:
             assert self.rgb_gt.ndim == 4, "rgb_gt must be a 4D tensor [B, H, W, 3]"
             assert self.rgb_gt.shape[0] == batch_size, "rgb_gt must have the same batch size"
-        # assert (
-        #     self.intrinsics is not None
-        #     or self.intrinsics_OpenCVPinholeCameraModelParameters is not None
-        #     or self.intrinsics_OpenCVFisheyeCameraModelParameters is not None
-        # ), "At least one of intrinsics must be provided."
+        if self.mask is not None:
+            assert self.mask.ndim == 4, "mask must be a 3D tensor [B, H, W, 1]"
+            assert self.mask.shape[0] == batch_size, "mask must have the same batch size"
         if self.intrinsics:
             assert isinstance(self.intrinsics, list), "intrinsics must be a list"
             assert len(self.intrinsics) == 4, "intrinsics must have 4 elements [fx, fy, cx, cy]"

--- a/threedgrut/trainer.py
+++ b/threedgrut/trainer.py
@@ -388,6 +388,12 @@ class Trainer3DGRUT:
         """
         rgb_gt = gpu_batch.rgb_gt
         rgb_pred = outputs["pred_rgb"]
+        mask = gpu_batch.mask
+        
+        # Mask out the invalid pixels if the mask is provided
+        if mask is not None:
+            rgb_gt = rgb_gt * mask
+            rgb_pred = rgb_pred * mask
 
         # L1 loss
         loss_l1 = torch.zeros(1, device=self.device)


### PR DESCRIPTION
Adds support for the images masks that are provided as gray scale images and stored in the same folder as the image, but with a `_mask.png` extension.

The masks are only used to ignore certain pixels in the loss computation, but don't affect the metrics.

Addresses: #48 