### PR TITLE
Add support for Sparse Adam optimizer. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,22 @@ python train.py --config-name apps/scannetpp_3dgrt.yaml path=data/scannetpp/0a5c
 python train.py --config-name apps/scannetpp_3dgut.yaml path=data/scannetpp/0a5c013435/dslr out_dir=runs experiment_name=0a5c013435_3dgut
 ```
 
-We also support MCMC densification strategy for 3DGRT and 3DGUT. To enable it, use the MCMC configuration:
+We also support MCMC densification strategy and selective Adam optimizer for 3DGRT and 3DGUT. 
+
+To enable MCMC, use:
 ```bash
-# Train Bonsai
 python train.py --config-name apps/colmap_3dgrt_mcmc.yaml path=data/mipnerf360/bonsai out_dir=runs experiment_name=bonsai_3dgrt dataset.downsample_factor=2 
 python train.py --config-name apps/colmap_3dgut_mcmc.yaml path=data/mipnerf360/bonsai out_dir=runs experiment_name=bonsai_3dgut dataset.downsample_factor=2 
 ```
 
-If you use MCMC in your research, please cite the original work and gSplat library from which the code was adopted (links to the code are provided in the source files).
+To enable selective Adam, use:
+```bash
+python train.py --config-name apps/colmap_3dgrt.yaml path=data/mipnerf360/bonsai out_dir=runs experiment_name=bonsai_3dgrt dataset.downsample_factor=2 optimizer.type=selective_adam
+python train.py --config-name apps/colmap_3dgut.yaml path=data/mipnerf360/bonsai out_dir=runs experiment_name=bonsai_3dgut dataset.downsample_factor=2 optimizer.type=selective_adam
+```
+
+If you use MCMC and Selective Adam in your research, please cite [3dgs-mcmck](https://github.com/ubc-vision/3dgs-mcmc), [taming-3dgs](https://github.com/humansensinglab/taming-3dgs),
+and [gSplat](https://github.com/nerfstudio-project/gsplat/tree/main) library from which the code was adopted (links to the code are provided in the source files).
 
 > [!Note] 
 > For ScanNet++, we expect the dataset to be preprocessed following [FisheyeGS](https://github.com/zmliao/Fisheye-GS?tab=readme-ov-file#prepare-training-data-on-scannet-dataset)'s method.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To mitigate this limitation, we also propose 3DGUT, which enables support for di
 
 ## 🔥 News
 - ✅[2025/04] Support for image masks.
-- [][2025/04] SparseAdam support.
+- ✅[2025/04] SparseAdam support.
 - ✅[2025/04] MCMC densification strategy support.
 - ✅[2025/04] Stable release [v1.0.0](https://github.com/nv-tlabs/3dgrut/releases/tag/v1.0.0) tagged.
 - ✅[2025/03] Initial code release!

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ python train.py --config-name apps/colmap_3dgrt_mcmc.yaml path=data/mipnerf360/b
 python train.py --config-name apps/colmap_3dgut_mcmc.yaml path=data/mipnerf360/bonsai out_dir=runs experiment_name=bonsai_3dgut dataset.downsample_factor=2 
 ```
 
+If you use MCMC in your research, please cite the original work and gSplat library from which the code was adopted (links to the code are provided in the source files).
+
 > [!Note] 
 > For ScanNet++, we expect the dataset to be preprocessed following [FisheyeGS](https://github.com/zmliao/Fisheye-GS?tab=readme-ov-file#prepare-training-data-on-scannet-dataset)'s method.
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,24 @@ bash ./benchmark/mipnerf360_render.sh results/mipnerf360
 | Treehill  | 23.11	| 0.650	| 508.6	| 365 |
 | *Average* | 27.78	| 0.822	| 596.7	| 308 |
 
+
+
+GS Strategy, Unsorted, Sparse Adam
+
+|           | PSNR   | SSIM  | Train (s) | FPS |
+|-----------|--------|-------|-----------|-----|
+| Bicycle   | 25.04  | 0.759 | 835.2     | -   |
+| Bonsai    | 32.63  | 0.945 | 457.1     | -   |
+| Counter   | 29.12  | 0.911 | 468.8     | -   |
+| Flowers   | 21.55  | 0.614 | 741.7     | -   |
+| Garden    | 27.12  | 0.855 | 757.4     | -   |
+| Kitchen   | 31.37  | 0.929 | 639.3     | -   |
+| Room      | 31.72  | 0.921 | 415.2     | -   |
+| Stump     | 26.58  | 0.774 | 695.7     | -   |
+| Treehill  | 22.30  | 0.625 | 749.8     | -   |
+| *Average* | 27.49  | 0.815 | 640.0     | -   |
+
+
 **Scannet++ Dataset**
 
 ```bash

--- a/configs/base_gs.yaml
+++ b/configs/base_gs.yaml
@@ -74,7 +74,7 @@ checkpoint:
   iterations: ${int_list:[ 7000, 30000 ]}
 
 optimizer:
-  type: adam # We only support adam for now
+  type: adam # We only support adam and selective_adam for now
   lr: 0.0
   eps: 1.e-15
   params:

--- a/threedgrt_tracer/include/3dgrt/optixTracer.h
+++ b/threedgrt_tracer/include/3dgrt/optixTracer.h
@@ -140,7 +140,7 @@ public:
 
     virtual ~OptixTracer();
 
-    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
     virtual trace(uint32_t frameNumber,
                   torch::Tensor rayToWorld,
                   torch::Tensor rayOri,

--- a/threedgrt_tracer/include/3dgrt/pipelineParameters.h
+++ b/threedgrt_tracer/include/3dgrt/pipelineParameters.h
@@ -29,6 +29,7 @@ struct PipelineParameters {
     const ParticleDensity* particleDensity; ///< position, scale, quaternions, density
     const float* particleRadiance;          ///< spherical harmonics coefficients
     const void* particleExtendedData;       ///< pipeline specific particle data
+    int32_t* particleVisibility;       ///< pipeline specific particle data
 
     PackedTensorAccessor32<float, 4> rayRadiance;    ///< output integrated ray radiance
     PackedTensorAccessor32<float, 4> rayDensity;     ///< output integrated ray density

--- a/threedgrt_tracer/src/kernels/cuda/barycentricSurfelsOptix.cu
+++ b/threedgrt_tracer/src/kernels/cuda/barycentricSurfelsOptix.cu
@@ -142,6 +142,9 @@ extern "C" __global__ void __raygen__rg() {
                     rayTransmittance *= (1 - rayParticleAlpha);
                     rayHitDistance += rayParticleHitDistance * rayParticleWeight;
 
+                    // NOTE(qi): Race condition here, but as we are writing the same value, it seems it is safe.
+                    params.particleVisibility[rayHit.particleId] = 1;
+
 #ifdef ENABLE_NORMALS
                     // fetch the normals from the precomputed normals buffer
                     const float3 rayParticleNormal = make_float3(particleNormalsDensity.x, particleNormalsDensity.y, particleNormalsDensity.z);

--- a/threedgrt_tracer/src/kernels/cuda/referenceOptix.cu
+++ b/threedgrt_tracer/src/kernels/cuda/referenceOptix.cu
@@ -154,6 +154,11 @@ extern "C" __global__ void __raygen__rg() {
                     nullptr
 #endif
                 );
+                
+                // NOTE(qi): Race condition here, but as we are writing the same value, it seems it is safe.            
+                if (acceptedHit) {
+                    params.particleVisibility[rayHit.particleId] = 1;
+                }
 
                 rayLastHitDistance = fmaxf(rayLastHitDistance, rayHit.distance);
 

--- a/threedgrt_tracer/src/kernels/cuda/referenceSlangOptix.cu
+++ b/threedgrt_tracer/src/kernels/cuda/referenceSlangOptix.cu
@@ -155,6 +155,11 @@ extern "C" __global__ void __raygen__rg() {
                                                        rayHit.particleId,
                                                        {{(float3*)params.particleRadiance, nullptr}, params.sphDegree},
                                                        &rayRadiance);
+                                                       
+                // NOTE(qi): Race condition here, but as we are writing the same value, it seems it is safe.
+                if (hitWeight > 0.f) {
+                    params.particleVisibility[rayHit.particleId] = 1;
+                }
                 
                 rayLastHitDistance = fmaxf(rayLastHitDistance, rayHit.distance);
 

--- a/threedgrt_tracer/src/optixTracer.cpp
+++ b/threedgrt_tracer/src/optixTracer.cpp
@@ -844,7 +844,7 @@ void OptixTracer::buildBVH(torch::Tensor mogPos,
     CUDA_CHECK_LAST();
 }
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 OptixTracer::trace(uint32_t frameNumber,
                    torch::Tensor rayToWorld,
                    torch::Tensor rayOri,
@@ -861,7 +861,8 @@ OptixTracer::trace(uint32_t frameNumber,
     torch::Tensor rayHit            = torch::empty({rayOri.size(0), rayOri.size(1), rayOri.size(2), 2}, opts);
     torch::Tensor rayNrm            = torch::empty({rayOri.size(0), rayOri.size(1), rayOri.size(2), 3}, opts);
     torch::Tensor rayHitsCount      = torch::zeros({rayOri.size(0), rayOri.size(1), rayOri.size(2), 1}, opts);
-
+    torch::Tensor particleVisibility = torch::zeros({particleDensity.size(0), 1}, opts);
+    
     PipelineParameters paramsHost;
     paramsHost.handle = _state->gasHandle;
     paramsHost.aabb   = _state->gasAABB;
@@ -883,6 +884,7 @@ OptixTracer::trace(uint32_t frameNumber,
     paramsHost.particleDensity      = getPtr<const ParticleDensity>(particleDensity);
     paramsHost.particleRadiance     = getPtr<const float>(particleRadiance);
     paramsHost.particleExtendedData = reinterpret_cast<const void*>(_state->gPipelineParticleData);
+    paramsHost.particleVisibility   = getPtr<int32_t>(particleVisibility);
 
     paramsHost.rayRadiance    = packed_accessor32<float, 4>(rayRad);
     paramsHost.rayDensity     = packed_accessor32<float, 4>(rayDns);
@@ -902,7 +904,7 @@ OptixTracer::trace(uint32_t frameNumber,
 
     CUDA_CHECK_LAST();
 
-    return std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>(rayRad, rayDns, rayHit, rayNrm, rayHitsCount);
+    return std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>(rayRad, rayDns, rayHit, rayNrm, rayHitsCount, particleVisibility);
 }
 
 std::tuple<torch::Tensor, torch::Tensor>

--- a/threedgrt_tracer/tracer.py
+++ b/threedgrt_tracer/tracer.py
@@ -231,7 +231,6 @@ class Tracer:
                 self.conf.render.min_transmittance,
             )
 
-            import pdb; pdb.set_trace()
             if self.frame_timer is not None:
                 self.frame_timer.end()
 

--- a/threedgrt_tracer/tracer.py
+++ b/threedgrt_tracer/tracer.py
@@ -231,6 +231,7 @@ class Tracer:
                 self.conf.render.min_transmittance,
             )
 
+            import pdb; pdb.set_trace()
             if self.frame_timer is not None:
                 self.frame_timer.end()
 

--- a/threedgrut/model/model.py
+++ b/threedgrut/model/model.py
@@ -573,6 +573,7 @@ class MixtureOfGaussians(torch.nn.Module):
         Returns:
             A dictionary containing the output of the model
         """
+        import pdb; pdb.set_trace()
 
         return self.renderer.render(self, batch, train, frame_id)
 

--- a/threedgrut/model/model.py
+++ b/threedgrut/model/model.py
@@ -490,8 +490,10 @@ class MixtureOfGaussians(torch.nn.Module):
 
         if self.conf.optimizer.type == "adam":
             self.optimizer = torch.optim.Adam(params, lr=self.conf.optimizer.lr, eps=self.conf.optimizer.eps)
+            logger.info("🔆 Using Adam optimizer")
         elif self.conf.optimizer.type == "selective_adam":
             self.optimizer = SelectiveAdam(params, lr=self.conf.optimizer.lr, eps=self.conf.optimizer.eps)
+            logger.info("🔆 Using Selective Adam optimizer")
         else:
             raise ValueError(f"Unknown optimizer type: {self.conf.optimizer.type}")
 
@@ -573,8 +575,6 @@ class MixtureOfGaussians(torch.nn.Module):
         Returns:
             A dictionary containing the output of the model
         """
-        import pdb; pdb.set_trace()
-
         return self.renderer.render(self, batch, train, frame_id)
 
     def trace(self, rays_o, rays_d, T_to_world=None):

--- a/threedgrut/model/model.py
+++ b/threedgrut/model/model.py
@@ -36,7 +36,7 @@ from threedgrut.utils.misc import (
     to_np, to_torch, quaternion_to_so3
 )
 from threedgrut.utils.render import RGB2SH
-
+from threedgrut.optimizers import SelectiveAdam
 
 class MixtureOfGaussians(torch.nn.Module):
     """ """
@@ -488,7 +488,12 @@ class MixtureOfGaussians(torch.nn.Module):
                 if module.requires_grad:
                     params.append({"params": [module], "name": name, **args})
 
-        self.optimizer = torch.optim.Adam(params, lr=self.conf.optimizer.lr, eps=self.conf.optimizer.eps)
+        if self.conf.optimizer.type == "adam":
+            self.optimizer = torch.optim.Adam(params, lr=self.conf.optimizer.lr, eps=self.conf.optimizer.eps)
+        elif self.conf.optimizer.type == "selective_adam":
+            self.optimizer = SelectiveAdam(params, lr=self.conf.optimizer.lr, eps=self.conf.optimizer.eps)
+        else:
+            raise ValueError(f"Unknown optimizer type: {self.conf.optimizer.type}")
 
         for param_group in self.optimizer.param_groups:
             if param_group["name"] == "positions":

--- a/threedgrut/optimizers/__init__.py
+++ b/threedgrut/optimizers/__init__.py
@@ -12,6 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# 
+#
+# Selective Adam implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/optimizers/selective_adam.py), 
+# which is based on the original implementation https://github.com/humansensinglab/taming-3dgs that uderlines the work
+#
+# Taming 3DGS: High-Quality Radiance Fields with Limited Resources by 
+# Saswat Subhajyoti Mallick*, Rahul Goel*, Bernhard Kerbl, Francisco Vicente Carrasco, Markus Steinberger and Fernando De La Torre
+# 
+# If you use this code in your research, please cite the above works.
 
 
 import os

--- a/threedgrut/optimizers/__init__.py
+++ b/threedgrut/optimizers/__init__.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from setuptools import find_packages, setup
+
+import torch
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+
+def setup_lib_optimizers_cc():
+
+    root_dir = os.path.abspath(os.path.dirname(__file__))
+
+    cpp_standard = 17
+
+    nvcc_flags = [
+        f"-std=c++{cpp_standard}",
+        "--extended-lambda",
+        "--expt-relaxed-constexpr",
+        # The following definitions must be undefined
+        # since TCNN requires half-precision operation.
+        "-U__CUDA_NO_HALF_OPERATORS__",
+        "-U__CUDA_NO_HALF_CONVERSIONS__",
+        "-U__CUDA_NO_HALF2_OPERATORS__",
+    ]
+
+    if os.name == "posix":
+        cflags = [f"-std=c++{cpp_standard}"]
+        nvcc_flags += [
+            "-Xcompiler=-Wno-float-conversion",
+            "-Xcompiler=-fno-strict-aliasing",
+        ]
+    elif os.name == "nt":
+        cflags = [f"/std:c++{cpp_standard}"]
+
+    include_paths = [root_dir]
+
+    # Linker options.
+    if os.name == "posix":
+        ldflags = ["-lcuda", "-lnvrtc"]
+    elif os.name == "nt":
+        ldflags = ["cuda.lib", "advapi32.lib", "nvrtc.lib"]
+
+    build_dir = torch.utils.cpp_extension._get_build_directory(
+        "lib_optimizers_cc", verbose=True
+    )
+
+    return torch.utils.cpp_extension.load(
+        name="lib_optimizers_cc",
+        sources=[
+            os.path.join(root_dir, "optimizers.cu"),
+            os.path.join(root_dir, "optimizers.cpp"),
+        ],
+        extra_cflags=cflags,
+        extra_cuda_cflags=nvcc_flags,
+        extra_ldflags=ldflags,
+        extra_include_paths=include_paths,
+        build_directory=build_dir,
+        with_cuda=True,
+        verbose=True,
+    )
+
+
+_CC = None
+
+if _CC is None:
+    _CC = setup_lib_optimizers_cc()
+
+
+class SelectiveAdam(torch.optim.Adam):
+    """
+    A custom optimizer that extends the standard Adam optimizer by
+    incorporating selective updates.
+
+    This class is useful for situations where only a subset of parameters
+    should be updated at each step, such as in sparse models or in cases where
+    parameter visibility is controlled by an external mask.
+
+    Additionally, the operations are fused into a single kernel. This optimizer
+    leverages the `adam` function from a CUDA backend for
+    optimized sparse updates.
+
+    This is one of the two optimizers mentioned in the Taming3DGS paper. This implementation
+    also references gsplat's SelectiveAdam optimizer.
+
+    Args:
+        params (iterable): Iterable of parameters to optimize or dicts defining parameter groups.
+        eps (float): Term added to the denominator to improve numerical stability (default: 1e-8).
+        betas (Tuple[float, float]): Coefficients used for computing running averages of gradient and its square (default: (0.9, 0.999)).
+
+    Examples:
+
+        >>> N = 100
+        >>> param = torch.randn(N, requires_grad=True)
+        >>> optimizer = SelectiveAdam([param], eps=1e-8, betas=(0.9, 0.999))
+        >>> visibility_mask = torch.cat([torch.ones(50), torch.zeros(50)])  # Visible first half, hidden second half
+
+        >>> # Forward pass
+        >>> loss = torch.sum(param ** 2)
+
+        >>> # Backward pass
+        >>> loss.backward()
+
+        >>> # Optimization step with selective updates
+        >>> optimizer.step(visibility=visibility_mask)
+
+    """
+
+    def __init__(self, params, lr=0.001, betas=(0.9, 0.999), eps=1e-08):
+        super().__init__(params=params, lr=lr, eps=eps, betas=betas)
+
+    @torch.no_grad()
+    def step(self, visibility):
+        for group in self.param_groups:
+            lr = group["lr"]
+            eps = group["eps"]
+            beta1, beta2 = group["betas"]
+
+            assert len(group["params"]) == 1, "More than one tensor in group is not supported"
+            param = group["params"][0]
+            if param.grad is None:
+                continue
+
+            # Lazy state initialization
+            state = self.state[param]
+            if len(state) == 0:
+                state["step"] = torch.tensor(0.0, dtype=torch.float32)
+                state["exp_avg"] = torch.zeros_like(
+                    param, memory_format=torch.preserve_format
+                )
+                state["exp_avg_sq"] = torch.zeros_like(
+                    param, memory_format=torch.preserve_format
+                )
+
+            stored_state = self.state.get(param, None)
+            exp_avg = stored_state["exp_avg"]
+            exp_avg_sq = stored_state["exp_avg_sq"]
+
+            _CC.selective_adam_update(
+                param.contiguous(),
+                param.grad.contiguous(),
+                exp_avg.contiguous(),
+                exp_avg_sq.contiguous(),
+                visibility.squeeze(),
+                lr,
+                beta1,
+                beta2,
+                eps,
+            )

--- a/threedgrut/optimizers/__init__.py
+++ b/threedgrut/optimizers/__init__.py
@@ -150,6 +150,7 @@ class SelectiveAdam(torch.optim.Adam):
             exp_avg = stored_state["exp_avg"]
             exp_avg_sq = stored_state["exp_avg_sq"]
 
+            import pdb; pdb.set_trace()
             _CC.selective_adam_update(
                 param.contiguous(),
                 param.grad.contiguous(),

--- a/threedgrut/optimizers/optimizers.cpp
+++ b/threedgrut/optimizers/optimizers.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <torch/extension.h>
+
+#include <ATen/TensorUtils.h>
+#include <ATen/core/Tensor.h>
+#include <c10/cuda/CUDAGuard.h> // for DEVICE_GUARD
+
+#define CHECK_CUDA(x) TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_CONTIGUOUS_CUDA(x) \
+    {                            \
+        CHECK_CUDA(x);           \
+        CHECK_CONTIGUOUS(x);     \
+    }
+
+namespace threedgrut
+{
+    void selective_adam_update_launch(
+        at::Tensor &param,            // [N, ...]
+        const at::Tensor &param_grad, // [N, ...]
+        at::Tensor &exp_avg,          // [N, ...]
+        at::Tensor &exp_avg_sq,       // [N, ...]
+        const at::Tensor &visibility, // [N]
+        const float lr,
+        const float b1,
+        const float b2,
+        const float eps);
+
+    void selective_adam_update(
+        torch::Tensor &param,            // [N, ...]
+        const torch::Tensor &param_grad, // [N, ...]
+        torch::Tensor &exp_avg,          // [N, ...]
+        torch::Tensor &exp_avg_sq,       // [N, ...]
+        const torch::Tensor &visibility, // [N]
+        const float lr,
+        const float b1,
+        const float b2,
+        const float eps)
+    {
+        const at::cuda::OptionalCUDAGuard device_guard(device_of(param));
+
+        CHECK_CONTIGUOUS_CUDA(param);
+        CHECK_CONTIGUOUS_CUDA(param_grad);
+        CHECK_CONTIGUOUS_CUDA(exp_avg);
+        CHECK_CONTIGUOUS_CUDA(exp_avg_sq);
+        CHECK_CONTIGUOUS_CUDA(visibility);
+
+        TORCH_CHECK(visibility.dim() == 1, "'visibility' should be 1D tensor");
+        TORCH_CHECK(visibility.size(0) == param.size(0), "'visibility' first dimension should have the same batch size as 'param'");
+
+        selective_adam_update_launch(param, param_grad, exp_avg, exp_avg_sq, visibility, lr, b1, b2, eps);
+    }
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def("selective_adam_update", &threedgrut::selective_adam_update);
+}

--- a/threedgrut/optimizers/optimizers.cpp
+++ b/threedgrut/optimizers/optimizers.cpp
@@ -12,14 +12,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
 //
-// Selective Adam implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/cuda/csrc/Adam.cpp), 
+//
+// Selective Adam implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/cuda/csrc/Adam.cpp),
 // which is based on the original implementation https://github.com/humansensinglab/taming-3dgs that uderlines the work
 //
-// Taming 3DGS: High-Quality Radiance Fields with Limited Resources by 
+// Taming 3DGS: High-Quality Radiance Fields with Limited Resources by
 // Saswat Subhajyoti Mallick*, Rahul Goel*, Bernhard Kerbl, Francisco Vicente Carrasco, Markus Steinberger and Fernando De La Torre
-// 
+//
 // If you use this code in your research, please cite the above works.
 
 #include <torch/extension.h>

--- a/threedgrut/optimizers/optimizers.cpp
+++ b/threedgrut/optimizers/optimizers.cpp
@@ -12,6 +12,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// 
+//
+// Selective Adam implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/cuda/csrc/Adam.cpp), 
+// which is based on the original implementation https://github.com/humansensinglab/taming-3dgs that uderlines the work
+//
+// Taming 3DGS: High-Quality Radiance Fields with Limited Resources by 
+// Saswat Subhajyoti Mallick*, Rahul Goel*, Bernhard Kerbl, Francisco Vicente Carrasco, Markus Steinberger and Fernando De La Torre
+// 
+// If you use this code in your research, please cite the above works.
 
 #include <torch/extension.h>
 

--- a/threedgrut/optimizers/optimizers.cu
+++ b/threedgrut/optimizers/optimizers.cu
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ATen/Dispatch.h> // AT_DISPATCH_XXX
+#include <ATen/core/Tensor.h>
+#include <c10/cuda/CUDAStream.h> // at::cuda::getCurrentCUDAStream
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+
+namespace cg = cooperative_groups;
+
+namespace threedgrut {
+
+// step on a grid of size (N, M)
+// N is always number of gaussians
+
+template <typename scalar_t>
+__global__ void selective_adam_update_kernel(
+    scalar_t *__restrict__ param,
+    const scalar_t *__restrict__ param_grad,
+    scalar_t *__restrict__ exp_avg,
+    scalar_t *__restrict__ exp_avg_sq,
+    const bool *__restrict__ visibility,
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps,
+    const uint32_t N,
+    const uint32_t M)
+{
+    auto p_idx = cg::this_grid().thread_rank();
+    const uint32_t g_idx = p_idx / M;
+
+    if (g_idx >= N)
+        return;
+
+    if (!visibility[g_idx])
+        return;
+
+    const float register_param_grad = param_grad[p_idx];
+
+    float register_exp_avg = exp_avg[p_idx];
+    float register_exp_avg_sq = exp_avg_sq[p_idx];
+    register_exp_avg = b1 * register_exp_avg + (1.0f - b1) * register_param_grad;
+    register_exp_avg_sq = b2 * register_exp_avg_sq + (1.0f - b2) * register_param_grad * register_param_grad;
+
+    const float step = -lr * register_exp_avg / (sqrt(register_exp_avg_sq) + eps);
+
+    param[p_idx] += step;
+    exp_avg[p_idx] = register_exp_avg;
+    exp_avg_sq[p_idx] = register_exp_avg_sq;
+}
+
+void selective_adam_update_launch(
+    at::Tensor &param,            // [N, ...]
+    const at::Tensor &param_grad, // [N, ...]
+    at::Tensor &exp_avg,          // [N, ...]
+    at::Tensor &exp_avg_sq,       // [N, ...]
+    const at::Tensor &visibility, // [N]
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps)
+{
+    const uint32_t N = param.size(0);
+    const uint32_t M = param.numel() / N;
+    const uint32_t n_elements = N * M;
+
+    // skip the kernel launch if there are no elements
+    if (n_elements == 0)
+        return;
+
+    // clang-format off
+    AT_DISPATCH_FLOATING_TYPES(param.scalar_type(), "adam_kernel", [&]() { 
+        selective_adam_update_kernel<scalar_t>
+            <<<(n_elements + 255) / 256, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+                param.data_ptr<scalar_t>(),
+                param_grad.data_ptr<scalar_t>(),
+                exp_avg.data_ptr<scalar_t>(),
+                exp_avg_sq.data_ptr<scalar_t>(),
+                visibility.data_ptr<bool>(),
+                lr, b1, b2, eps, N, M
+            );
+    });
+    // clang-format on
+}
+
+}

--- a/threedgrut/optimizers/optimizers.cu
+++ b/threedgrut/optimizers/optimizers.cu
@@ -14,14 +14,13 @@
 // limitations under the License.
 //
 //
-// Selective Adam implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/cuda/csrc/AdamCUDA.cu), 
+// Selective Adam implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/cuda/csrc/AdamCUDA.cu),
 // which is based on the original implementation https://github.com/humansensinglab/taming-3dgs that uderlines the work
 //
-// Taming 3DGS: High-Quality Radiance Fields with Limited Resources by 
+// Taming 3DGS: High-Quality Radiance Fields with Limited Resources by
 // Saswat Subhajyoti Mallick*, Rahul Goel*, Bernhard Kerbl, Francisco Vicente Carrasco, Markus Steinberger and Fernando De La Torre
-// 
+//
 // If you use this code in your research, please cite the above works.
-
 
 #include <ATen/Dispatch.h> // AT_DISPATCH_XXX
 #include <ATen/core/Tensor.h>
@@ -32,80 +31,81 @@
 
 namespace cg = cooperative_groups;
 
-namespace threedgrut {
-
-// step on a grid of size (N, M)
-// N is always number of gaussians
-
-template <typename scalar_t>
-__global__ void selective_adam_update_kernel(
-    scalar_t *__restrict__ param,
-    const scalar_t *__restrict__ param_grad,
-    scalar_t *__restrict__ exp_avg,
-    scalar_t *__restrict__ exp_avg_sq,
-    const bool *__restrict__ visibility,
-    const float lr,
-    const float b1,
-    const float b2,
-    const float eps,
-    const uint32_t N,
-    const uint32_t M)
+namespace threedgrut
 {
-    auto p_idx = cg::this_grid().thread_rank();
-    const uint32_t g_idx = p_idx / M;
 
-    if (g_idx >= N)
-        return;
+    // step on a grid of size (N, M)
+    // N is always number of gaussians
 
-    if (!visibility[g_idx])
-        return;
+    template <typename scalar_t>
+    __global__ void selective_adam_update_kernel(
+        scalar_t *__restrict__ param,
+        const scalar_t *__restrict__ param_grad,
+        scalar_t *__restrict__ exp_avg,
+        scalar_t *__restrict__ exp_avg_sq,
+        const bool *__restrict__ visibility,
+        const float lr,
+        const float b1,
+        const float b2,
+        const float eps,
+        const uint32_t N,
+        const uint32_t M)
+    {
+        auto p_idx = cg::this_grid().thread_rank();
+        const uint32_t g_idx = p_idx / M;
 
-    const float register_param_grad = param_grad[p_idx];
+        if (g_idx >= N)
+            return;
 
-    float register_exp_avg = exp_avg[p_idx];
-    float register_exp_avg_sq = exp_avg_sq[p_idx];
-    register_exp_avg = b1 * register_exp_avg + (1.0f - b1) * register_param_grad;
-    register_exp_avg_sq = b2 * register_exp_avg_sq + (1.0f - b2) * register_param_grad * register_param_grad;
+        if (!visibility[g_idx])
+            return;
 
-    const float step = -lr * register_exp_avg / (sqrt(register_exp_avg_sq) + eps);
+        const float register_param_grad = param_grad[p_idx];
 
-    param[p_idx] += step;
-    exp_avg[p_idx] = register_exp_avg;
-    exp_avg_sq[p_idx] = register_exp_avg_sq;
-}
+        float register_exp_avg = exp_avg[p_idx];
+        float register_exp_avg_sq = exp_avg_sq[p_idx];
+        register_exp_avg = b1 * register_exp_avg + (1.0f - b1) * register_param_grad;
+        register_exp_avg_sq = b2 * register_exp_avg_sq + (1.0f - b2) * register_param_grad * register_param_grad;
 
-void selective_adam_update_launch(
-    at::Tensor &param,            // [N, ...]
-    const at::Tensor &param_grad, // [N, ...]
-    at::Tensor &exp_avg,          // [N, ...]
-    at::Tensor &exp_avg_sq,       // [N, ...]
-    const at::Tensor &visibility, // [N]
-    const float lr,
-    const float b1,
-    const float b2,
-    const float eps)
-{
-    const uint32_t N = param.size(0);
-    const uint32_t M = param.numel() / N;
-    const uint32_t n_elements = N * M;
+        const float step = -lr * register_exp_avg / (sqrt(register_exp_avg_sq) + eps);
 
-    // skip the kernel launch if there are no elements
-    if (n_elements == 0)
-        return;
+        param[p_idx] += step;
+        exp_avg[p_idx] = register_exp_avg;
+        exp_avg_sq[p_idx] = register_exp_avg_sq;
+    }
 
-    // clang-format off
-    AT_DISPATCH_FLOATING_TYPES(param.scalar_type(), "adam_kernel", [&]() { 
-        selective_adam_update_kernel<scalar_t>
-            <<<(n_elements + 255) / 256, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
-                param.data_ptr<scalar_t>(),
-                param_grad.data_ptr<scalar_t>(),
-                exp_avg.data_ptr<scalar_t>(),
-                exp_avg_sq.data_ptr<scalar_t>(),
-                visibility.data_ptr<bool>(),
-                lr, b1, b2, eps, N, M
-            );
-    });
-    // clang-format on
-}
+    void selective_adam_update_launch(
+        at::Tensor &param,            // [N, ...]
+        const at::Tensor &param_grad, // [N, ...]
+        at::Tensor &exp_avg,          // [N, ...]
+        at::Tensor &exp_avg_sq,       // [N, ...]
+        const at::Tensor &visibility, // [N]
+        const float lr,
+        const float b1,
+        const float b2,
+        const float eps)
+    {
+        const uint32_t N = param.size(0);
+        const uint32_t M = param.numel() / N;
+        const uint32_t n_elements = N * M;
+
+        // skip the kernel launch if there are no elements
+        if (n_elements == 0)
+            return;
+
+        // clang-format off
+        AT_DISPATCH_FLOATING_TYPES(param.scalar_type(), "adam_kernel", [&]() { 
+            selective_adam_update_kernel<scalar_t>
+                <<<(n_elements + 255) / 256, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+                    param.data_ptr<scalar_t>(),
+                    param_grad.data_ptr<scalar_t>(),
+                    exp_avg.data_ptr<scalar_t>(),
+                    exp_avg_sq.data_ptr<scalar_t>(),
+                    visibility.data_ptr<bool>(),
+                    lr, b1, b2, eps, N, M
+                );
+        });
+        // clang-format on
+    }
 
 }

--- a/threedgrut/optimizers/optimizers.cu
+++ b/threedgrut/optimizers/optimizers.cu
@@ -12,6 +12,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+//
+// Selective Adam implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/cuda/csrc/AdamCUDA.cu), 
+// which is based on the original implementation https://github.com/humansensinglab/taming-3dgs that uderlines the work
+//
+// Taming 3DGS: High-Quality Radiance Fields with Limited Resources by 
+// Saswat Subhajyoti Mallick*, Rahul Goel*, Bernhard Kerbl, Francisco Vicente Carrasco, Markus Steinberger and Fernando De La Torre
+// 
+// If you use this code in your research, please cite the above works.
+
 
 #include <ATen/Dispatch.h> // AT_DISPATCH_XXX
 #include <ATen/core/Tensor.h>

--- a/threedgrut/optimizers/setup_optimizers.py
+++ b/threedgrut/optimizers/setup_optimizers.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Selective Adam implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/optimizers/selective_adam.py),
+# which is based on the original implementation https://github.com/humansensinglab/taming-3dgs that uderlines the work
+#
+# Taming 3DGS: High-Quality Radiance Fields with Limited Resources by
+# Saswat Subhajyoti Mallick*, Rahul Goel*, Bernhard Kerbl, Francisco Vicente Carrasco, Markus Steinberger and Fernando De La Torre
+#
+# If you use this code in your research, please cite the above works.
+
+
+import os
+import torch
+
+
+def setup_lib_optimizers_cc():
+    root_dir = os.path.abspath(os.path.dirname(__file__))
+    cpp_standard = 17
+
+    nvcc_flags = [
+        f"-std=c++{cpp_standard}",
+        "--extended-lambda",
+        "--expt-relaxed-constexpr",
+        # The following definitions must be undefined
+        # since TCNN requires half-precision operation.
+        "-U__CUDA_NO_HALF_OPERATORS__",
+        "-U__CUDA_NO_HALF_CONVERSIONS__",
+        "-U__CUDA_NO_HALF2_OPERATORS__",
+    ]
+
+    if os.name == "posix":
+        cflags = [f"-std=c++{cpp_standard}"]
+        nvcc_flags += [
+            "-Xcompiler=-Wno-float-conversion",
+            "-Xcompiler=-fno-strict-aliasing",
+        ]
+    elif os.name == "nt":
+        cflags = [f"/std:c++{cpp_standard}"]
+
+    include_paths = [root_dir]
+
+    # Linker options.
+    if os.name == "posix":
+        ldflags = ["-lcuda", "-lnvrtc"]
+    elif os.name == "nt":
+        ldflags = ["cuda.lib", "advapi32.lib", "nvrtc.lib"]
+
+    build_dir = torch.utils.cpp_extension._get_build_directory(
+        "lib_optimizers_cc", verbose=True
+    )
+
+    return torch.utils.cpp_extension.load(
+        name="lib_optimizers_cc",
+        sources=[
+            os.path.join(root_dir, "optimizers.cu"),
+            os.path.join(root_dir, "optimizers.cpp"),
+        ],
+        extra_cflags=cflags,
+        extra_cuda_cflags=nvcc_flags,
+        extra_ldflags=ldflags,
+        extra_include_paths=include_paths,
+        build_directory=build_dir,
+        with_cuda=True,
+        verbose=True,
+    )

--- a/threedgrut/strategy/mcmc.py
+++ b/threedgrut/strategy/mcmc.py
@@ -12,6 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# MCMC implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/strategy/mcmc.py), 
+# which is based on the original implementation https://github.com/ubc-vision/3dgs-mcmc that uderlines the work
+#
+# 3D Gaussian Splatting as Markov Chain Monte Carlo by 
+# Shakiba Kheradmand, Daniel Rebain, Gopal Sharma, Weiwei Sun, Yang-Che Tseng, Hossam Isack, Abhishek Kar, Andrea Tagliasacchi and Kwang Moo Yie
+#
+# If you use this code in your research, please cite the above works.
 
 import math
 from typing import Optional, Tuple

--- a/threedgrut/strategy/src/bindings.cpp
+++ b/threedgrut/strategy/src/bindings.cpp
@@ -12,6 +12,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// MCMC implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/cuda/csrc/Relocation.cpp), 
+// which is based on the original implementation https://github.com/ubc-vision/3dgs-mcmc that uderlines the work
+//
+// 3D Gaussian Splatting as Markov Chain Monte Carlo by 
+// Shakiba Kheradmand, Daniel Rebain, Gopal Sharma, Weiwei Sun, Yang-Che Tseng, Hossam Isack, Abhishek Kar, Andrea Tagliasacchi and Kwang Moo Yie
+//
+// If you use this code in your research, please cite the above works.
 
 #include "gaussian_mcmc.h"
 #include <vector>

--- a/threedgrut/strategy/src/gaussian_mcmc.cu
+++ b/threedgrut/strategy/src/gaussian_mcmc.cu
@@ -12,6 +12,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// MCMC implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/strategy/mcmc.py), 
+// which is based on the original implementation https://github.com/ubc-vision/3dgs-mcmc that uderlines the work
+//
+// 3D Gaussian Splatting as Markov Chain Monte Carlo by 
+// Shakiba Kheradmand, Daniel Rebain, Gopal Sharma, Weiwei Sun, Yang-Che Tseng, Hossam Isack, Abhishek Kar, Andrea Tagliasacchi and Kwang Moo Yie
+//
+// If you use this code in your research, please cite the above works.
 
 #include "gaussian_mcmc.h"
 #include <ATen/cuda/CUDAContext.h>

--- a/threedgrut/strategy/src/gaussian_mcmc.h
+++ b/threedgrut/strategy/src/gaussian_mcmc.h
@@ -12,7 +12,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//
+// MCMC implementation was adpoted from gSplat library (https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/strategy/mcmc.py), 
+// which is based on the original implementation https://github.com/ubc-vision/3dgs-mcmc that uderlines the work
+//
+// 3D Gaussian Splatting as Markov Chain Monte Carlo by 
+// Shakiba Kheradmand, Daniel Rebain, Gopal Sharma, Weiwei Sun, Yang-Che Tseng, Hossam Isack, Abhishek Kar, Andrea Tagliasacchi and Kwang Moo Yie
+//
+// If you use this code in your research, please cite the above works.
 
 #pragma once
 

--- a/threedgrut/trainer.py
+++ b/threedgrut/trainer.py
@@ -41,7 +41,7 @@ from threedgrut.utils.gui import GUI
 from threedgrut.utils.logger import logger
 from threedgrut.utils.timer import CudaTimer
 from threedgrut.utils.misc import jet_map, create_summary_writer, check_step_condition
-
+from threedgrut.optimizers import SelectiveAdam
 
 class Trainer3DGRUT:
     """Trainer for paper: "3D Gaussian Ray Tracing: Fast Tracing of Particle Scenes" """
@@ -705,6 +705,7 @@ class Trainer3DGRUT:
             # Compute the outputs of a single batch
             with torch.cuda.nvtx.range(f"train_{global_step}_fwd"):
                 profilers["inference"].start()
+                import pdb; pdb.set_trace()
                 outputs = model(gpu_batch, train=True, frame_id=global_step)
                 profilers["inference"].end()
 
@@ -730,7 +731,11 @@ class Trainer3DGRUT:
 
             # Optimizer step
             with torch.cuda.nvtx.range(f"train_{global_step}_backprop"):
-                model.optimizer.step()
+                if isinstance(model.optimizer, SelectiveAdam):
+                    assert outputs['mog_visibility'].shape == model.density.shape, f"Visibility shape {outputs['mog_visibility'].shape} does not match density shape {model.density.shape}"
+                    model.optimizer.step(outputs['mog_visibility'])
+                else:
+                    model.optimizer.step()
                 model.optimizer.zero_grad()
 
             # Scheduler step

--- a/threedgrut/trainer.py
+++ b/threedgrut/trainer.py
@@ -705,7 +705,6 @@ class Trainer3DGRUT:
             # Compute the outputs of a single batch
             with torch.cuda.nvtx.range(f"train_{global_step}_fwd"):
                 profilers["inference"].start()
-                import pdb; pdb.set_trace()
                 outputs = model(gpu_batch, train=True, frame_id=global_step)
                 profilers["inference"].end()
 

--- a/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutRenderer.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutRenderer.cuh
@@ -31,6 +31,7 @@ __global__ void projectOnTiles(tcnn::uvec2 tileGrid,
                                tcnn::vec2* __restrict__ particlesProjectedExtentPtr,
                                float* __restrict__ particlesGlobalDepthPtr,
                                float* __restrict__ particlesPrecomputedFeaturesPtr,
+                               int* __restrict__ particlesVisibilityCudaPtr,
                                const uint64_t* __restrict__ parameterMemoryHandles) {
 
     TGUTProjector::eval(tileGrid,
@@ -46,6 +47,7 @@ __global__ void projectOnTiles(tcnn::uvec2 tileGrid,
                         particlesProjectedExtentPtr,
                         particlesGlobalDepthPtr,
                         particlesPrecomputedFeaturesPtr,
+                        particlesVisibilityCudaPtr,
                         {parameterMemoryHandles});
 }
 

--- a/threedgut_tracer/include/3dgut/renderer/gutRenderer.h
+++ b/threedgut_tracer/include/3dgut/renderer/gutRenderer.h
@@ -68,6 +68,7 @@ public:
                          float* worldHitCountCudaPtr,
                          float* worldHitDistanceCudaPtr,
                          tcnn::vec4* radianceDensityCudaPtr,
+                         int* particlesVisibilityCudaPtr,
                          Parameters& parameters,
                          int cudaDeviceIndex,
                          cudaStream_t cudaStream);

--- a/threedgut_tracer/include/3dgut/splatRaster.h
+++ b/threedgut_tracer/include/3dgut/splatRaster.h
@@ -48,7 +48,7 @@ public:
 
     ~SplatRaster();
 
-    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
     trace(uint32_t frameNumber, int numActiveFeatures,
           // Particles
           torch::Tensor particleDensity,

--- a/threedgut_tracer/src/gutRenderer.cu
+++ b/threedgut_tracer/src/gutRenderer.cu
@@ -238,6 +238,7 @@ threedgut::Status threedgut::GUTRenderer::renderForward(const RenderParameters& 
                                                         float* worldHitCountCudaPtr,
                                                         float* worldHitDistanceCudaPtr,
                                                         vec4* radianceDensityCudaPtr,
+                                                        int* particlesVisibilityCudaPtr,
                                                         Parameters& parameters,
                                                         int cudaDeviceIndex,
                                                         cudaStream_t cudaStream) {
@@ -282,6 +283,7 @@ threedgut::Status threedgut::GUTRenderer::renderForward(const RenderParameters& 
             (tcnn::vec2*)m_forwardContext->particlesProjectedExtent.data(),
             (float*)m_forwardContext->particlesGlobalDepth.data(),
             (float*)m_forwardContext->particlesPrecomputedFeatures.data(),
+            particlesVisibilityCudaPtr,
             parameters.m_dptrParametersBuffer);
         CUDA_CHECK_STREAM_RETURN(cudaStream, m_logger);
     }

--- a/threedgut_tracer/src/splatRaster.cpp
+++ b/threedgut_tracer/src/splatRaster.cpp
@@ -164,7 +164,7 @@ SplatRaster::SplatRaster(const nlohmann::json& config)
 SplatRaster::~SplatRaster(void) {
 }
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 SplatRaster::trace(uint32_t frameNumber, int numActiveFeatures,
                    torch::Tensor particleDensity,
                    torch::Tensor particleRadiance,
@@ -190,6 +190,7 @@ SplatRaster::trace(uint32_t frameNumber, int numActiveFeatures,
     torch::Tensor rayRadianceDensity = torch::zeros({height, width, 4}, opts);
     torch::Tensor rayHitDistance     = torch::ones({height, width, 1}, opts).multiply(1e06f);
     torch::Tensor rayHitCount        = torch::zeros({height, width, 1}, opts);
+    torch::Tensor particleVisibility = torch::zeros({numParticles, 1}, opts);
 
     m_parameters.values.numParticles               = numParticles;
     m_parameters.values.radianceSphDegree          = numActiveFeatures;
@@ -222,6 +223,7 @@ SplatRaster::trace(uint32_t frameNumber, int numActiveFeatures,
         reinterpret_cast<float*>(voidDataPtr(rayHitCount)),
         reinterpret_cast<float*>(voidDataPtr(rayHitDistance)),
         reinterpret_cast<tcnn::vec4*>(voidDataPtr(rayRadianceDensity)),
+        reinterpret_cast<int*>(voidDataPtr(particleVisibility)),
         m_parameters,
         cudaDeviceIndex,
         cudaStream);
@@ -232,7 +234,7 @@ SplatRaster::trace(uint32_t frameNumber, int numActiveFeatures,
         timer->stop();
     }
 
-    return std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>(rayRadianceDensity, rayHitDistance, rayHitCount);
+    return std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>(rayRadianceDensity, rayHitDistance, rayHitCount, particleVisibility);
 }
 
 std::tuple<torch::Tensor, torch::Tensor>

--- a/threedgut_tracer/tracer.py
+++ b/threedgut_tracer/tracer.py
@@ -185,7 +185,7 @@ class Tracer:
                 * sensor_poses.timestamps_us[0]
             )
 
-            ray_radiance_density, ray_hit_distance, ray_hit_count = tracer_wrapper.trace(
+            ray_radiance_density, ray_hit_distance, ray_hit_count, mog_visibility = tracer_wrapper.trace(
                 frame_id,
                 n_active_features,
                 particle_density,
@@ -220,6 +220,7 @@ class Tracer:
                 ray_radiance_density,
                 ray_hit_distance,
                 ray_hit_count,
+                mog_visibility,
             )
 
         @staticmethod
@@ -227,7 +228,8 @@ class Tracer:
             ctx,
             ray_radiance_density_grd,
             ray_hit_distance_grd,
-            *unused,
+            ray_hit_count_grd_UNUSED,
+            mog_visibility_grd_UNUSED,
         ):
             (
                 ray_ori,
@@ -311,6 +313,7 @@ class Tracer:
                 pred_rgba,
                 pred_dist,
                 hits_count,
+                mog_visibility,
             ) = Tracer._Autograd.apply(
                 self.tracer_wrapper,
                 frame_id,
@@ -344,6 +347,7 @@ class Tracer:
             "pred_normals": torch.nn.functional.normalize(torch.ones_like(pred_rgb), dim=3),
             "hits_count": hits_count,
             "frame_time_ms": timings["forward_render"] if "forward_render" in timings else 0.0,
+            "mog_visibility": mog_visibility,
         }
 
     @staticmethod


### PR DESCRIPTION
This PR add support for Sparse/Selective Adam optimizer as proposed by:

[Saswat Subhajyoti Mallick, Rahul Goel, Bernhard Kerbl, Francisco Vicente Carrasco, Markus Steinberger, Fernando De La Torre: Taming 3DGS: High-Quality Radiance Fields with Limited Resources](https://github.com/humansensinglab/taming-3dgs)

the code is adapted from [gSPLAT library](https://github.com/nerfstudio-project/gsplat).

The optimizer can be selected from the CLI as `optimizer.type=selective_adam  `