### PR TITLE
Enable training with all images

### DIFF
--- a/configs/dataset/colmap.yaml
+++ b/configs/dataset/colmap.yaml
@@ -1,2 +1,3 @@
 type: colmap
 downsample_factor: 1
+test_split_interval: 8

--- a/configs/dataset/scannetpp.yaml
+++ b/configs/dataset/scannetpp.yaml
@@ -1,2 +1,3 @@
 type: scannetpp
 downsample_factor: 1
+test_split_interval: 8

--- a/threedgrut/datasets/__init__.py
+++ b/threedgrut/datasets/__init__.py
@@ -66,3 +66,32 @@ def make(name: str, config, ray_jitter):
             )
 
     return train_dataset, val_dataset
+
+
+def make_test(name: str, config):
+    match name:
+        case "nerf":
+            dataset = NeRFDataset(
+                config.path,
+                split="test",
+                bg_color=config.model.background.color,
+            )
+        case "colmap":
+            dataset = ColmapDataset(
+                config.path,
+                split="val",
+                downsample_factor=config.dataset.downsample_factor,
+                test_split_interval=config.dataset.test_split_interval,
+            )
+        case "scannetpp":
+            dataset = ScannetppDataset(
+                config.path,
+                split="val",
+                downsample_factor=config.dataset.downsample_factor,
+                test_split_interval=config.dataset.test_split_interval,
+            )
+        case _:
+            raise ValueError(
+                f'Unsupported dataset type: {config.dataset.type}. Choose between: ["colmap", "nerf", "scannetpp"].'
+            )
+    return dataset

--- a/threedgrut/datasets/__init__.py
+++ b/threedgrut/datasets/__init__.py
@@ -37,22 +37,28 @@ def make(name: str, config, ray_jitter):
                 config.path,
                 split="train",
                 downsample_factor=config.dataset.downsample_factor,
+                test_split_interval=config.dataset.test_split_interval,
                 ray_jitter=ray_jitter,
             )
             val_dataset = ColmapDataset(
                 config.path,
                 split="val",
                 downsample_factor=config.dataset.downsample_factor,
+                test_split_interval=config.dataset.test_split_interval,
             )
         case "scannetpp":
             train_dataset = ScannetppDataset(
                 config.path,
                 split="train",
                 ray_jitter=ray_jitter,
+                downsample_factor=config.dataset.downsample_factor,
+                test_split_interval=config.dataset.test_split_interval,
             )
             val_dataset = ScannetppDataset(
                 config.path,
                 split="val",
+                downsample_factor=config.dataset.downsample_factor,
+                test_split_interval=config.dataset.test_split_interval,
             )
         case _:
             raise ValueError(

--- a/threedgrut/datasets/dataset_colmap.py
+++ b/threedgrut/datasets/dataset_colmap.py
@@ -47,7 +47,13 @@ from .camera_models import (
 
 class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
     def __init__(
-        self, path, device="cuda", split="train", downsample_factor=1, test_split_interval=8, ray_jitter=None,
+        self,
+        path,
+        device="cuda",
+        split="train",
+        downsample_factor=1,
+        test_split_interval=8,
+        ray_jitter=None,
     ):
         self.path = path
         self.device = device

--- a/threedgrut/datasets/dataset_scannetpp.py
+++ b/threedgrut/datasets/dataset_scannetpp.py
@@ -21,8 +21,8 @@ from .utils import read_colmap_extrinsics_text, read_colmap_intrinsics_text
 
 class ScannetppDataset(ColmapDataset):
 
-    def __init__(self, path, device="cuda", split="train", ray_jitter=None):
-        super(ScannetppDataset, self).__init__(path, device, split, ray_jitter)
+    def __init__(self, path, device="cuda", split="train", downsample_factor=1, test_split_interval=8, ray_jitter=None):
+        super(ScannetppDataset, self).__init__(path, device, split, downsample_factor, test_split_interval, ray_jitter)
 
     def load_intrinsics_and_extrinsics(self):
         cameras_extrinsic_file = os.path.join(self.path, "colmap", "images.txt")

--- a/threedgrut/datasets/dataset_scannetpp.py
+++ b/threedgrut/datasets/dataset_scannetpp.py
@@ -21,8 +21,18 @@ from .utils import read_colmap_extrinsics_text, read_colmap_intrinsics_text
 
 class ScannetppDataset(ColmapDataset):
 
-    def __init__(self, path, device="cuda", split="train", downsample_factor=1, test_split_interval=8, ray_jitter=None):
-        super(ScannetppDataset, self).__init__(path, device, split, downsample_factor, test_split_interval, ray_jitter)
+    def __init__(
+        self,
+        path,
+        device="cuda",
+        split="train",
+        downsample_factor=1,
+        test_split_interval=8,
+        ray_jitter=None,
+    ):
+        super(ScannetppDataset, self).__init__(
+            path, device, split, downsample_factor, test_split_interval, ray_jitter
+        )
 
     def load_intrinsics_and_extrinsics(self):
         cameras_extrinsic_file = os.path.join(self.path, "colmap", "images.txt")

--- a/threedgrut/datasets/protocols.py
+++ b/threedgrut/datasets/protocols.py
@@ -24,7 +24,9 @@ import numpy as np
 class Batch:
     rays_ori: torch.Tensor  # [B, H, W, 3] ray origins in arbitrary space
     rays_dir: torch.Tensor  # [B, H, W, 3] ray directions in arbitrary space
-    T_to_world: torch.Tensor  # [B, 4, 4] transformation matrix from the ray space to the world space
+    T_to_world: (
+        torch.Tensor
+    )  # [B, 4, 4] transformation matrix from the ray space to the world space
     rgb_gt: Optional[torch.Tensor] = None
     mask: Optional[torch.Tensor] = None
     intrinsics: Optional[list] = None
@@ -33,17 +35,27 @@ class Batch:
 
     def __post_init__(self):
         batch_size = self.T_to_world.shape[0]
-        assert self.rays_ori.shape[0] == batch_size, "rays_ori must have the same batch size"
-        assert self.rays_dir.shape[0] == batch_size, "rays_dir must have the same batch size"
+        assert (
+            self.rays_ori.shape[0] == batch_size
+        ), "rays_ori must have the same batch size"
+        assert (
+            self.rays_dir.shape[0] == batch_size
+        ), "rays_dir must have the same batch size"
         if self.rgb_gt is not None:
             assert self.rgb_gt.ndim == 4, "rgb_gt must be a 4D tensor [B, H, W, 3]"
-            assert self.rgb_gt.shape[0] == batch_size, "rgb_gt must have the same batch size"
+            assert (
+                self.rgb_gt.shape[0] == batch_size
+            ), "rgb_gt must have the same batch size"
         if self.mask is not None:
             assert self.mask.ndim == 4, "mask must be a 3D tensor [B, H, W, 1]"
-            assert self.mask.shape[0] == batch_size, "mask must have the same batch size"
+            assert (
+                self.mask.shape[0] == batch_size
+            ), "mask must have the same batch size"
         if self.intrinsics:
             assert isinstance(self.intrinsics, list), "intrinsics must be a list"
-            assert len(self.intrinsics) == 4, "intrinsics must have 4 elements [fx, fy, cx, cy]"
+            assert (
+                len(self.intrinsics) == 4
+            ), "intrinsics must have 4 elements [fx, fy, cx, cy]"
 
 
 class BoundedMultiViewDataset(Protocol):
@@ -53,11 +65,11 @@ class BoundedMultiViewDataset(Protocol):
         """Returns the bounding box of the scene as a tuple of vec3 (min,max)"""
         ...
 
-    def get_scene_extent(self) -> float: 
+    def get_scene_extent(self) -> float:
         """TODO"""
         ...
 
-    def get_observer_points(self) -> np.ndarray: 
+    def get_observer_points(self) -> np.ndarray:
         """TODO"""
         ...
 

--- a/threedgrut/render.py
+++ b/threedgrut/render.py
@@ -23,7 +23,7 @@ from torchmetrics import PeakSignalNoiseRatio
 from torchmetrics.image import StructuralSimilarityIndexMeasure
 from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
 
-from threedgrut.datasets import NeRFDataset, ColmapDataset, ScannetppDataset
+import threedgrut.datasets as datasets
 from threedgrut.model.model import MixtureOfGaussians
 from threedgrut.utils.logger import logger
 from threedgrut.utils.misc import create_summary_writer
@@ -57,20 +57,7 @@ class Renderer:
     def create_test_dataloader(self, conf):
         """Create the test dataloader for the given configuration."""
 
-        match conf.dataset.type:
-            case "nerf":
-                dataset = NeRFDataset(
-                    conf.path, split="test", bg_color=conf.model.background.color
-                )
-            case "colmap":
-                dataset = ColmapDataset(conf.path, split="val", downsample_factor=conf.dataset.downsample_factor)
-            case "scannetpp":
-                dataset = ScannetppDataset(conf.path, split="val")
-            case _:
-                raise ValueError(
-                    f'Unsupported dataset type: {conf.dataset.type}. Choose between: ["colmap", "nerf", "scannetpp"].'
-                )
-
+        dataset = datasets.make_test(name=conf.dataset.type, config=conf)
         dataloader = torch.utils.data.DataLoader(dataset, num_workers=8, batch_size=1, shuffle=False, collate_fn=None)
         return dataset, dataloader
 


### PR DESCRIPTION
This MR enables training with a different test interval and hence also with all images when using the Colmap or ScannetPP datasets. This option is controlled through the config parameter: `config.dataset.test_split_interval ` the default setting is 8, but e.g. setting it to -1 results in training and testing with all images (overfitting example)

Minor: 
- fixes a small bug in the scannetpp dataset where the parent class was missing the downsampling parameter