### PR TITLE
Playground 2.0 - Updated Path Tracer with Cook Torrance, PBR materials, Env Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To mitigate this limitation, we also propose 3DGUT, which enables support for di
 
 
 ## 🔥 News
+- ✅[2025/06] Playground supports PBR meshes and environment maps.
 - ✅[2025/04] Support for image masks.
 - ✅[2025/04] SparseAdam support.
 - ✅[2025/04] MCMC densification strategy support.

--- a/playground.py
+++ b/playground.py
@@ -19,15 +19,16 @@ import os
 import argparse
 
 
-def run_demo(gs_object, mesh_assets_folder, default_gs_config, buffer_mode):
+def run_demo(gs_object, mesh_assets_folder, envmap_assets_folder, default_gs_config, buffer_mode):
     """
     How to run:
     > python playground.py --gs_object <ckpt_path>
                           [--mesh_assets <mesh_folder_path>]
                           [--default_gs_config <config_name>]
+                          [--envmap_assets <hdr_folder_path>]
                           [--buffer_mode <host2device | device2device>]
     """
-    playground = Playground(gs_object, mesh_assets_folder, default_gs_config, buffer_mode)
+    playground = Playground(gs_object, mesh_assets_folder, default_gs_config, envmap_assets_folder, buffer_mode)
     playground.run()
 
 
@@ -52,6 +53,12 @@ if __name__ == "__main__":
         help="Name of default config to use for .ingp, .ply files, or .pt files not trained with 3dgrt."
     )
     parser.add_argument(
+        '--envmap_assets',
+        type=str,
+        default=os.path.join(os.path.dirname(__file__), 'threedgrut_playground', 'assets'),
+        help="Optional path to folder containing .hdr environment maps to use for lighting mesh assets."
+    )
+    parser.add_argument(
         '--buffer_mode',
         type=str,
         choices=["host2device", "device2device"],
@@ -64,6 +71,7 @@ if __name__ == "__main__":
     run_demo(
         gs_object=args.gs_object,
         mesh_assets_folder=args.mesh_assets,
+        envmap_assets_folder=args.envmap_assets,
         default_gs_config=args.default_gs_config,
         buffer_mode=args.buffer_mode
     )

--- a/threedgrut_playground/README.md
+++ b/threedgrut_playground/README.md
@@ -9,6 +9,8 @@ The **Playground** is an interactive demo app that showcases various effects in 
 
 ## 🔥 News
 
+- ✅[2025/06] 3DGRUT's playground engine is featured in [Kaolin's CVPR 2025 Tutorial](https://kaolin.readthedocs.io/en/latest/notes/cvpr2025.html).
+- ✅[2025/06] Playground v2.0 releaed: Path tracing of PBR meshes and environment maps added.
 - ✅[2025/04] Headless mode added (Engine3DGRUT is now exposed as api).
 - ✅[2025/03] Playground v1.0 released (3dgrt + Glass, Mirrors, Diffuse Meshes, Depth of Field)
 
@@ -29,7 +31,9 @@ The **Playground** is an interactive demo app that showcases various effects in 
       - [🫙 Glass](#-glass)
       - [🪞 Mirror](#-mirror)
       - [🔵 Diffused Mesh](#-diffused-mesh)
+      - [💎 PBR Mesh](#-pbr-mesh)
     - [🖌️ Materials](#-materials)
+    - [🌇️ Environment Maps](#-environment-maps)
     - [⚙️ Quick Settings](#-quick-settings)
     - [📸 Depth of Field](#-depth-of-field)
     - [✨ Antialiasing](#-antialiasing)
@@ -50,7 +54,7 @@ conda install -c conda-forge mesa-libgl-devel-cos7-x86_64 # may be necessary for
 pip install -r threedgrut_playground/requirements.txt
 ```
 
-3. Download a pack of interesting mesh assets:
+3. Download a pack of interesting mesh assets and env maps:
 ```bash
 chmod +x ./threedgrut_playground/download_assets.sh
 ./threedgrut_playground/download_assets.sh
@@ -84,6 +88,9 @@ The playground will load them automatically as available *primitives* as soon as
 Some interesting shapes are [available here](https://github.com/alecjacobson/common-3d-test-models/tree/master).
 A subset of those are downloaded with the `download_assets.sh` script.
 
+As of June 2025, the script will also download some sample `.hdr` env-maps, which
+can be used to provide global light to PBR meshes.
+
 5. Have fun experimenting! 
 
 #### Additional args
@@ -91,11 +98,14 @@ A subset of those are downloaded with the `download_assets.sh` script.
 ```
 python playground.py --gs_object <ckpt_path>  
                      [--mesh_assets <mesh_folder_path>]
+                     [--envmap_assets <hdr_folder_path>]
                      [--default_gs_config <config_name>]
                      [--buffer_mode <"host2device" | "device2device">]
 ```
 The full run command includes the following optional args:
 * `--mesh_assets`: Path to folder containing mesh assets of .obj or .glb format. 
+  * Defaults to `threedgrut_playground/assets`.
+* `--envmap_assets`: Path to folder containing environment maps of .hdr format.
   * Defaults to `threedgrut_playground/assets`.
 * `--default_gs_config`: Name of default config to use for .ingp, .ply files, or .pt files not trained with 3dgrt.
   * Defaults to `apps/colmap_3dgrt.yaml`.
@@ -116,6 +126,8 @@ properties. These changes are memorized but not applied yet.
 depending on redirection computed in step 1.
 
 The process continues until the ray misses or accumulates enough radiance.
+When a ray misses, if env maps are enabled, they will also contribute radiance to the ray. 
+That is - both env maps and gaussians are used to light PBR primitives in the scene.
 
 For antialiasing and depth of field, multiple rendering passes are used with ray jittering.
 
@@ -161,6 +173,21 @@ diffuse mesh color.
 
 Diffused Mesh primitives can assign different materials.
 
+#### 💎 PBR Mesh
+PBR Meshes use Cook-Torrance shading, to render meshes with Physically Based materials.
+The path tracer supports BRDF and BTDF of meshes alongside volumetric radiance intergration of Gaussian fields.
+
+The approach taken by this path tracer is pragmatic, 
+rather than principled, as hybrid rendering is an open research problem:
+Here, 3DGRT particles are treated as radiating particles, while meshes absorb and scatter light.
+Note that 3DGRT uses baked light for radiance, and therefore Gaussian particles are not affected by light sources.
+In addition, envmaps assume HDR, which may require some tuning to match the rest of the scene.
+
+PBR Meshes rely on Monte Carlo for high quality rendering, and therefore require antialiasing toggled on.
+Quality improves with the number of SPPs.
+
+PBR Mesh primitives can assign different materials, and their properties may be edited in the materials section.
+
 ### 🖌️ Materials
 
 The materials section includes a property editor for all loaded materials in the scene.
@@ -168,6 +195,26 @@ The materials section includes a property editor for all loaded materials in the
 By default, a *solid* and *checkboard* materials should always be available (the latter using a texture for diffuse color).
 
 If `.gltf` / `.glb` files are loaded with additional materials, these materials would appear under this menu.
+
+### 🌇️ Environment Maps
+
+Environment maps can be loaded to provide global light in the scene, and override the model background.
+
+When the engine loads, a list of available env maps is populated. Then envmaps can be selected from the dropdown.
+
+Note that env maps are only enabled when path tracing is enabled, and at least 1 mesh primitive is added to the scene.
+
+Env maps provide light in High Dynamic Range (HDR). The IBL Intensity (Image Based Lighting Intensity) and Exposure
+allow to scale the range up and down, to adjust the light according to the selected env map and scene.
+
+IBL Intensity is a linear scalar multiplier applied to the env map before path tracing.
+
+After the path tracer runs and an image is rendered, Exposure is applied with $$hdr=hdr*2^{exposure},$$
+just before tone mapping takes place.
+
+Tone mapping, if enabled, is applied next, followed by gamma correction.
+
+The position of the env map can also be adjusted by the offset sliders.
 
 ### ⚙️ Quick Settings
 

--- a/threedgrut_playground/download_assets.sh
+++ b/threedgrut_playground/download_assets.sh
@@ -69,4 +69,8 @@ for asset in "${assets[@]}"; do
     download_file "$asset"
 done
 
+echo "Downloading sample envmaps from PolyHaven"
+wget -q --show-progress -O "$output_dir/drackenstein_quarry_puresky_2k.hdr" "https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/2k/drackenstein_quarry_puresky_2k.hdr"
+wget -q --show-progress -O "$output_dir/drackenstein_quarry_puresky_4k.hdr" "https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/4k/drackenstein_quarry_puresky_4k.hdr"
+
 echo "✅ Download complete. Files saved in '$output_dir'"

--- a/threedgrut_playground/include/playground/hybridTracer.h
+++ b/threedgrut_playground/include/playground/hybridTracer.h
@@ -148,10 +148,8 @@ public:
                 const std::vector<CPBRMaterial>& materials,
                 bool shouldSyncMaterials,
                 torch::Tensor refractiveIndex,
-                torch::Tensor backgroundColor,
                 torch::Tensor envmap,
-                bool enableEnvmap,
-                bool useEnvmapAsBackground,
+                torch::Tensor envmapOffset,
                 const unsigned int maxPBRBounces);
 
     torch::Tensor denoise(torch::Tensor rayRad);

--- a/threedgrut_playground/include/playground/kernels/cuda/materials.cuh
+++ b/threedgrut_playground/include/playground/kernels/cuda/materials.cuh
@@ -30,6 +30,8 @@ extern "C"
     #endif
 }
 
+constexpr float PBR_EPS = 1e-6;     // Minimal eps to avoid zero division
+
 static __device__ __inline__ const PBRMaterial& get_material(const unsigned int matId)
 {
     return params.materials[matId];
@@ -67,5 +69,387 @@ static __device__ __inline__ float3 get_diffuse_color(const float3 ray_d, float3
     return diffuse * shade;
 }
 
+/* Dot product, limited to positive values, clamped otherwise */
+static __device__ __inline__ float positive_dot(const float3 a, const float3 b)
+{
+    return clamp(dot(a, b), 0.0f, 1.0f);
+}
+
+/* Step function*/
+static __device__ __inline__ float heaviside(float x)
+{
+    return x > 0 ? 1.0 : 0.0;
+}
+
+static __device__ inline float3 normalize(float3 v)
+{
+    const float norm = dot(v,v);
+    return (norm > PBR_EPS) ? v * rsqrtf(norm) : v;
+}
+
+static __device__ __inline__ bool has_precomputed_tangents()
+{
+    const unsigned int triId = optixGetPrimitiveIndex();
+    const unsigned int v0_idx = params.triangles[triId][0];
+    const unsigned int v1_idx = params.triangles[triId][1];
+    const unsigned int v2_idx = params.triangles[triId][2];
+    return params.vHasTangents[v0_idx][0] && params.vHasTangents[v1_idx][0] && params.vHasTangents[v2_idx][0];
+}
+
+static __device__ __inline__ float3 get_smooth_tangent()
+{
+    // Uses interpolated vertex tangents to get a smooth varying interpolated tangent
+    const unsigned int triId = optixGetPrimitiveIndex();
+    const unsigned int v0_idx = params.triangles[triId][0];
+    const unsigned int v1_idx = params.triangles[triId][1];
+    const unsigned int v2_idx = params.triangles[triId][2];
+    const float3 t0 = make_float3(params.vTangents[v0_idx][0], params.vTangents[v0_idx][1], params.vTangents[v0_idx][2]);
+    const float3 t1 = make_float3(params.vTangents[v1_idx][0], params.vTangents[v1_idx][1], params.vTangents[v1_idx][2]);
+    const float3 t2 = make_float3(params.vTangents[v2_idx][0], params.vTangents[v2_idx][1], params.vTangents[v2_idx][2]);
+    const float2 barycentric = optixGetTriangleBarycentrics();
+    float3 interpolated_tangent = (1 - barycentric.x - barycentric.y) * t0 + barycentric.x * t1 + barycentric.y * t2;
+    interpolated_tangent /= length(interpolated_tangent);
+
+    return interpolated_tangent;
+}
+
+// Computes TBN matrix and multiplies dir
+static __device__ __inline__ float3 compute_normal_space(const float3 normal, const float3 dir)
+{
+    float3 tangent;
+    float3 bitangent;
+
+    if (has_precomputed_tangents()) {
+        tangent = get_smooth_tangent();
+    }
+    else {
+        if (fabs(normal.x) > fabs(normal.z))
+            tangent = make_float3(-normal.y, normal.x, 0.0f);
+        else
+            tangent = make_float3(0.0f, -normal.z, normal.y);
+    }
+    tangent = normalize(tangent);
+    bitangent = normalize(cross(normal, tangent));
+
+    // Create TBN matrix
+    float3 worldNormal;
+    worldNormal.x = tangent.x * dir.x + bitangent.x * dir.y + normal.x * dir.z;
+    worldNormal.y = tangent.y * dir.x + bitangent.y * dir.y + normal.y * dir.z;
+    worldNormal.z = tangent.z * dir.x + bitangent.z * dir.y + normal.z * dir.z;
+    return normalize(worldNormal);
+}
+
+static __device__ __inline__ float3 importance_sample_diffuse_ggx(
+    const float3 normal, const float random_theta_seed, const float random_phi_seed)
+{
+    const float theta = asin(random_theta_seed);    // changed from asin(sqrtf(random_theta_seed));
+    const float phi = 2.0 * pi() * random_phi_seed;
+    // Sampled indirect diffuse direction in normal space
+    const float3 local_diffuse_dir = make_float3(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta));
+    float3 L = compute_normal_space(normal, local_diffuse_dir);
+    return L;
+}
+
+static __device__ __inline__ float3 importance_sample_specular_ggx(
+    const float3 normal, const float random_theta_seed, const float random_phi_seed, const float roughness
+)
+{
+    const float alpha = roughness * roughness;
+    const float theta = acos(sqrtf((1.0 - random_theta_seed) / (1.0 + (alpha * alpha - 1.0) * random_theta_seed)));
+    const float phi = 2.0 * pi() * random_phi_seed;
+
+    const float3 local_H = make_float3(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta));
+    float3 H = compute_normal_space(normal, local_H);
+    return H;
+}
+
+static __device__ __inline__ bool alpha_test(
+    const float alpha,
+    const unsigned int alphaMode,
+    const float alphaCutoff,
+    unsigned int& rndSeed)
+{
+    // Run alpha test according to:
+    // https://github.com/KhronosGroup/glTF-Sample-Models/blob/main/2.0/AlphaBlendModeTest/README.md
+    // If returns true, alpha test succeeds, if false the current hit should be ignored ("no material")
+    if (alphaMode == GLTFBlend) {
+        return alpha > rnd(rndSeed);
+    }
+    else if (alphaMode == GLTFMask) {
+        return alpha > alphaCutoff;
+    }
+    else { // Opaque
+        return true;
+    }
+}
+
+/* D: Normal distribution function approximation */
+static __device__ __inline__ float trowbridge_reitz_ggx(
+    const float3 h,     // halfway vector
+    const float3 normal,
+    const float roughness)
+{
+    const float alpha = roughness * roughness;
+    const float alpha_sqr = alpha * alpha;
+    const float n_dot_h = positive_dot(normal, h);
+    const float denom = n_dot_h * n_dot_h * (alpha_sqr - 1.0) + 1.0;
+    return alpha_sqr / fmaxf((pi() * denom * denom), PBR_EPS);
+}
+
+/* G: Geometry function: microfacet occlusion approximation */
+static __device__ __inline__ float geometry_schlick_ggx(const float n_dot_v, const float roughness)
+{
+    const float alpha = 0.5 * roughness * roughness;
+    const float denom = n_dot_v * (1.0 - alpha) + alpha;
+    return n_dot_v / fmaxf(denom, PBR_EPS);
+}
+
+/* G: Geometry function: microfacet occlusion approximation */
+static __device__ __inline__ float geometry_smith(
+    const float normal_dot_wo,
+    const float normal_dot_wi,
+    const float roughness)
+{
+    return geometry_schlick_ggx(normal_dot_wo, roughness) * geometry_schlick_ggx(normal_dot_wi, roughness);
+}
+
+/* F: Reflectance function: Fresnel Schlick approximation */
+static __device__ __inline__ float3 fresnel_schlick(const float cosine, const float3 F0)
+{
+    return F0 + (1.0 - F0) * powf(1.0 - cosine, 5.0);
+}
+
+static __device__ __inline__ float3 pbr_refract(float3 wi, float3 normal, float eta)
+{
+    const float normal_dot_wi = dot(normal, wi);
+    const float k = 1.0 - eta * eta * (1.0 - normal_dot_wi * normal_dot_wi);
+    return (k < 0.0) ? make_float3(0.0) : eta * wi - (eta * normal_dot_wi + sqrtf(k)) * normal;
+}
+
+static __device__ __inline__ unsigned int getFrameNumber()
+{
+    const uint3 idx = optixGetLaunchIndex();
+    return params.frameNumber + idx.z;
+}
+
+static __device__ __inline__ float3 sampled_microfacet_brdf(
+    const float3 wo,
+    const float3 normal,
+    const float3 base_color,
+    const float metalness,
+    const float roughness,
+    const float transmission,
+    const float ior,
+    float3& next_ray_dir,
+    unsigned int& rndSeed,
+    HybridRayPayload* payload
+)
+{
+    // Outputs
+    float3 out_factor;
+    float3 L;
+
+    // Constant values
+    const float fresnel_reflect = 0.5;
+
+    // Stochastic variables
+    const uint3 idx = optixGetLaunchIndex();
+    const float3 rand = rnd_pcg3d(make_uint3(idx.x, idx.y, getFrameNumber() + payload->pbrNumBounces));
+//     const float3 rand = rnd3(rndSeed);   // Enable for an alternative randomization procedure
+    const float random_phi_seed = rand.x;
+    const float random_theta_seed = rand.y;
+    const float ray_prob = rand.z;
+
+    if ((ray_prob < 0.5f) && ((2.0 * ray_prob) < transmission))
+    { // Transmissive
+        float frontFacing = dot(wo, normal);
+        float3 forwardNormal;
+        float eta;
+        if (frontFacing >= 0.0) {
+            forwardNormal = normal;
+            eta = 1.0 / ior;
+        }
+        else {
+            forwardNormal = -normal;
+            eta = ior;
+        }
+
+        // Importance sampling transmittance
+        const float3 H = importance_sample_specular_ggx(forwardNormal, random_theta_seed, random_phi_seed, roughness);
+        L = pbr_refract(-wo, H, eta);
+
+        const float fnormal_dot_wo = positive_dot(forwardNormal, wo);
+        const float fnormal_dot_L = positive_dot(-forwardNormal, L);
+        const float fnormal_dot_H = positive_dot(forwardNormal, H);
+        const float wo_dot_H = positive_dot(wo, H);
+
+        // F0 for dielectics in range [0.0, 0.16]
+        // default FO is (0.16 * 0.5^2) = 0.04
+        float3 f0 = make_float3(0.16 * fresnel_reflect * fresnel_reflect);
+        // in case of metals, baseColor contains F0
+        f0 = lerp(f0, base_color, metalness);
+
+        float3 F = fresnel_schlick(wo_dot_H, f0);
+        float D = trowbridge_reitz_ggx(H, forwardNormal, roughness);
+        float G = geometry_smith(fnormal_dot_wo, fnormal_dot_L, roughness);
+        out_factor = base_color * (make_float3(1.0) - F) * G * wo_dot_H / fmaxf((fnormal_dot_H * fnormal_dot_wo), 0.001);
+    }
+    else if ((ray_prob < 0.5f) && ((2.0 * ray_prob) >= transmission))
+    {  // Diffuse
+        // Importance sampling diffuse
+        L = importance_sample_diffuse_ggx(normal, random_theta_seed, random_phi_seed);
+
+        // Half vector
+        const float3 H = normalize(wo + L);
+
+        const float wo_dot_H = positive_dot(wo, H);
+        // F0 for dielectics in range [0.0, 0.16]
+        // default FO is (0.16 * 0.5^2) = 0.04
+        float3 f0 = make_float3(0.16 * (fresnel_reflect * fresnel_reflect));
+        // in case of metals, baseColor contains F0
+        f0 = lerp(f0, base_color, metalness);
+        float3 F = fresnel_schlick(wo_dot_H, f0);
+
+        // If not specular, use as diffuse
+        float3 not_spec = make_float3(1.0) - F;
+        // no diffuse for metals
+        not_spec *= (1.0 - metalness);
+
+        out_factor = not_spec * base_color;
+    }
+    else
+    {
+        // Specular
+        // important sample GGX
+        const float3 H = importance_sample_specular_ggx(normal, random_theta_seed, random_phi_seed, roughness);
+        L = -wo - 2.0 * dot(H, -wo) * H;
+
+        const float normal_dot_wo = positive_dot(normal, wo);
+        const float normal_dot_H = positive_dot(normal, H);
+        const float normal_dot_L = positive_dot(normal, L);
+        const float wo_dot_H = positive_dot(wo, H);
+
+        // F0 for dielectics in range [0.0, 0.16]
+        // default FO is (0.16 * 0.5^2) = 0.04
+        float3 f0 = make_float3(0.16 * fresnel_reflect * fresnel_reflect);
+        f0 = lerp(f0, base_color, metalness);
+
+        // specular microfacet (cook-torrance) BRDF
+        float3 F = fresnel_schlick(wo_dot_H, f0);
+        float D = trowbridge_reitz_ggx(H, normal, roughness);
+        float G = geometry_smith(normal_dot_wo, normal_dot_L, roughness);
+        out_factor = F * G * wo_dot_H / fmaxf((normal_dot_H * normal_dot_wo), 0.001);
+    }
+
+    out_factor *= 2.0; // compensate for splitting diffuse and specular
+    next_ray_dir = L;
+    payload->pbrNumBounces = payload->pbrNumBounces + 1;
+    return make_float3(out_factor.x, out_factor.y, out_factor.z);
+}
+
+// Parts of implementation adopted from Thorsten Thormählen's Path Tracer at:
+// https://www.gsn-lib.org/apps/raytracing/index.php?name=example_transmission
+static __device__ __inline__ void sampled_cook_torrance_brdf(
+    const float3 ray_o,
+    const float3 ray_d,
+    const float hit_t,
+    float3 normal,
+    float3& new_ray_dir,
+    unsigned int& rndSeed,
+    HybridRayPayload* payload)
+{
+    const float3 wo = normalize(-ray_d);            // Out light reflects back at the viewer's direction
+    const float3 hit_point = ray_o + hit_t * ray_d; // 3D Point where the ray hit the surface
+
+    const unsigned int triId = optixGetPrimitiveIndex();
+    const unsigned int materialId = params.matID[triId][0];
+    const auto material = get_material(materialId);
+
+    const float2 uv0 = make_float2(params.matUV[triId][0][0], params.matUV[triId][0][1]);
+    const float2 uv1 = make_float2(params.matUV[triId][1][0], params.matUV[triId][1][1]);
+    const float2 uv2 = make_float2(params.matUV[triId][2][0], params.matUV[triId][2][1]);
+    const float2 barycentric = optixGetTriangleBarycentrics();
+    float2 texCoords = (1 - barycentric.x - barycentric.y) * uv0 + barycentric.x * uv1 + barycentric.y * uv2;
+
+    float3 diffuse;
+    float3 emissive;
+    float metallic;
+    float roughness;
+    float transmission;
+    float ior;
+    bool disablePBRTextures = params.playgroundOpts & PGRNDRenderDisablePBRTextures;
+
+    float3 diffuseFactor = make_float3(material.diffuseFactor.x, material.diffuseFactor.y, material.diffuseFactor.z);
+    float alpha = material.diffuseFactor.w;
+    if (!material.useDiffuseTexture || disablePBRTextures)
+    {
+        diffuse = diffuseFactor;
+    }
+    else
+    {
+        cudaTextureObject_t diffuseTex = material.diffuseTexture;
+        float4 diffuse_fp4 = tex2D<float4>(diffuseTex, texCoords.x, texCoords.y);
+        diffuse = make_float3(diffuse_fp4.x, diffuse_fp4.y, diffuse_fp4.z);
+        diffuse *= diffuseFactor;
+        alpha *= diffuse_fp4.w;
+    }
+
+    if (!material.useEmissiveTexture || disablePBRTextures)
+    {
+        emissive = material.emissiveFactor;
+    }
+    else
+    {
+        cudaTextureObject_t emissiveTex = material.emissiveTexture;
+        float4 emissive_fp4 = tex2D<float4>(emissiveTex, texCoords.x, texCoords.y);
+        emissive = make_float3(emissive_fp4.x, emissive_fp4.y, emissive_fp4.z) * material.emissiveFactor;
+    }
+
+    if (!material.useMetallicRoughnessTexture || disablePBRTextures)
+    {
+        metallic = material.metallicFactor;
+        roughness = material.roughnessFactor;
+    }
+    else
+    {
+        cudaTextureObject_t metallicRoughnessTex = material.metallicRoughnessTexture;
+        float2 metallic_roughness_fp2 = tex2D<float2>(metallicRoughnessTex, texCoords.x, texCoords.y);
+        metallic = metallic_roughness_fp2.x * material.metallicFactor;
+        roughness = metallic_roughness_fp2.y * material.roughnessFactor;
+    }
+
+    if (material.useNormalTexture && !disablePBRTextures)
+    {
+        cudaTextureObject_t normalTex = material.normalTexture;
+        const float4 normal_fp4 = tex2D<float4>(normalTex, texCoords.x, texCoords.y);
+        float3 normal_tex = make_float3(normal_fp4.x, normal_fp4.y, normal_fp4.z);
+        normal = compute_normal_space(normal, normal_tex);
+    }
+
+    transmission = material.transmissionFactor;
+    ior = material.ior;
+
+    // gltf 2.0 alpha test - for "no material"
+    if (!alpha_test(alpha, material.alphaMode, material.alphaCutoff, rndSeed)) {
+        new_ray_dir = ray_d;
+        return;
+    }
+
+    const float3 nextScatter = sampled_microfacet_brdf(
+        wo,
+        normal,
+        diffuse,
+        metallic,
+        roughness,
+        transmission,
+        ior,
+        new_ray_dir,
+        rndSeed,
+        payload
+    );
+    const float3 nextEmissive = emissive;
+    payload->bsdfValue = maxf3(nextScatter, make_float3(0.0));
+    payload->nextEmissive = nextEmissive;
+}
 
 #endif

--- a/threedgrut_playground/include/playground/kernels/cuda/rng.cuh
+++ b/threedgrut_playground/include/playground/kernels/cuda/rng.cuh
@@ -51,15 +51,28 @@ static __host__ __device__ __inline__ unsigned int lcg2(unsigned int& prev)
     return prev;
 }
 
-// Generate random float in [0, 1)
+// Generate random float in [0, 1) - using Linear Congruential Generator (LCG)
 static __host__ __device__ __inline__ float rnd(unsigned int& prev)
 {
     return ((float)lcg(prev) / (float)0x01000000);
 }
 
+// Generate random float3 in [0, 1) - using Linear Congruential Generator (LCG)
 static __host__ __device__ __inline__ float3 rnd3(unsigned int& prev)
 {
     return make_float3(rnd(prev),rnd(prev),rnd(prev));
+}
+
+// Generate random float3 in [0, 1) - using Permuted Congruential Generator (PCG)
+static __device__ __inline__ float3 rnd_pcg3d(uint3 v)
+{
+  v.x = v.x * 1664525u + 1013904223u;
+  v.y = v.y * 1664525u + 1013904223u;
+  v.z = v.z * 1664525u + 1013904223u;
+  v.x += v.y*v.z; v.y += v.z*v.x; v.z += v.x*v.y;
+  v.x ^= v.x >> 16u; v.y ^= v.y >> 16u; v.z ^= v.z >> 16u;
+  v.x += v.y*v.z; v.y += v.z*v.x; v.z += v.x*v.y;
+  return make_float3(v.x, v.y, v.z) * (1.0/float(0xffffffffu));
 }
 
 #endif

--- a/threedgrut_playground/include/playground/pipelineDefinitions.h
+++ b/threedgrut_playground/include/playground/pipelineDefinitions.h
@@ -20,22 +20,22 @@ enum PlaygroundPrimitiveTypes
     PGRNDPrimitiveNone = 0,
     PGRNDPrimitiveMirror = 1,
     PGRNDPrimitiveGlass = 2,
-    PGRNDPrimitiveDiffuse = 3
+    PGRNDPrimitiveDiffuse = 3,
+    PGRNDPrimitivePBR = 4
 };
 
 enum PlaygroundTraceState
 {
-    PGRNDTraceRTLastGaussiansPass = 0,   // Tracing gaussians with volumetric rendering - until scene extents are hit
-    PGRNDTracePrimitivesPass = 1,        // Tracing mirrors, glasses, meshes..
-    PGRNDTraceRTGaussiansPass = 2,       // Tracing gaussians with volumetric rendering
-    PGRNDTraceTerminate = 3,             // Terminate current ray
+    PGRNDTracePrimitivesPass = 0,        // Tracing mirrors, glasses, meshes..
+    PGRNDTraceRTGaussiansPass = 1,       // Tracing Gaussians with volumetric rendering
+    PGRNDTraceTerminate = 2              // Terminate current ray
 };
 
 enum PlaygroundRenderOptions
 {
     PGRNDRenderNone = 0,
     PGRNDRenderSmoothNormals = 1<<0,           // Geometry: If enabled, will interpolate precomputed vertex normals
-    PGRNDRenderDisableGaussianTracing = 1<<1,  // Disable gaussian tracing -- only meshes will be rendered
+    PGRNDRenderDisableGaussianTracing = 1<<1,  // Disable Gaussian tracing -- only meshes will be rendered
     PGRNDRenderDisablePBRTextures = 1<<2       // Disable PBR textures, use base material values only
 };
 

--- a/threedgrut_playground/include/playground/pipelineParameters.h
+++ b/threedgrut_playground/include/playground/pipelineParameters.h
@@ -50,10 +50,8 @@ struct alignas(16) PBRMaterial
 struct PlaygroundPipelineParameters: PipelineParameters
 {
     PackedTensorAccessor32<float, 3> rayMaxT; ///< ray max t for termination
-    bool useEnvmap;
-    bool useEnvmapAsBackground;
-    float3 backgroundColor;     // Optional, only if useEnvmap is False
-    cudaTextureObject_t envmap; // Optional, only if useEnvmap is True
+    cudaTextureObject_t envmap;               // for envmaps and solid background color
+    float2 envmapOffset;                      // rotates env map along (theta, phi) axis
 
     // -- Playground specific launch params --
     OptixTraversableHandle triHandle;   // Handle to BVH of mesh primitives: mirrors, glasses, pbr..

--- a/threedgrut_playground/requirements.txt
+++ b/threedgrut_playground/requirements.txt
@@ -3,6 +3,6 @@ tqdm
 libigl
 pygltflib
 polyscope>=2.3.0
-warp-lang==1.2.1    # unused, installed to avoid cuda<12.0 version warnings if installed by other dependencies
 -f https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.1.2_cu118.html
 kaolin==0.17.0
+opencv-python

--- a/threedgrut_playground/tracer.py
+++ b/threedgrut_playground/tracer.py
@@ -202,10 +202,8 @@ class Tracer:
         materials=None,
         is_sync_materials=True,
         refractive_index=None,
-        background_color=None,
         envmap=None,
-        enable_envmap=False,
-        use_envmap_as_background=False,
+        envmap_offset=None,
         max_pbr_bounces=7
     ):
         if ray_max_t is None:
@@ -220,10 +218,10 @@ class Tracer:
             materials = []
         else:
             materials = [self.to_native_pbr_material(m) for m in materials]
-        if background_color is None:
-            background_color = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32)
         if envmap is None:
-            envmap = torch.empty([0, 0, 0], dtype=torch.float32)
+            envmap = torch.zeros([4, 4, 4], dtype=torch.float32)
+        if envmap_offset is None:
+            envmap = torch.zeros([2], dtype=torch.float32)
 
         poses = torch.tensor([
             [1, 0, 0, 0],
@@ -246,6 +244,7 @@ class Tracer:
             particle_density = torch.concat([mog_pos, mog_dns, mog_rot, mog_scl, torch.zeros_like(mog_dns)], dim=1)
             sph_degree = gaussians.n_active_features
             min_transmittance = self.conf.render.min_transmittance
+            envmap_offset = envmap_offset.contiguous()
 
             (
                 pred_rgb,
@@ -274,10 +273,8 @@ class Tracer:
                 materials,
                 is_sync_materials,
                 refractive_index,
-                background_color,
                 envmap,
-                enable_envmap,
-                use_envmap_as_background,
+                envmap_offset,
                 max_pbr_bounces
             )
 

--- a/threedgrut_playground/utils/environment.py
+++ b/threedgrut_playground/utils/environment.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import imageio
+import imageio.plugins.freeimage as fi
+import numpy as np
+import torch
+from typing import Optional
+
+
+class Environment:
+    """Manages environment maps & background color for the 3DGRUT engine.
+
+    Handles loading, tonemapping, and processing of HDR environment maps.
+    Supports multiple tonemapping algorithms and exposure control.
+
+    Attributes:
+        folder (str): Path to folder containing .hdr files
+        envmap (torch.Tensor): Current processed environment map, ready to use with renderer
+        _hdr_data (np.ndarray): Unprocessed HDR data of currently picked  environment map
+        current_name (str): Name of currently loaded environment map
+        tonemapper (str): Current tonemapping algorithm
+        exposure (float): Current exposure value
+        saturation (float): Color saturation value
+        scale (float): Scale factor for tonemapping
+    """
+    FIXED_ENVMAP_OPTIONS =  ['Model-Background', 'Black', 'White']
+    TONEMAPPER_OPTIONS = ['None', 'Reinhard', 'Filmic']
+
+    def __init__(self, folder: Optional[str] = None, device: Optional[torch.device] = None):
+
+        self.device = device
+
+        """ Name of last hdr loaded from disk, or None if no envmap is currently loaded. """
+        self.current_name = 'Model-Background'
+
+        # Tone-map settings
+        """ Tonemapping algorithm used """
+        self.tonemapper = 'None'
+        """ Image Based Lighting Intensity (linearly scales HDR data) """
+        self.ibl_intensity = 1.0
+        """ Exposure value - applies 2**exposure to the image just before tone mapping """
+        self.exposure = 0.0
+
+        # HDR map fields
+        """ Contains the last hdr map data loaded, before tone mapping """
+        self._hdr_data = None
+        """ Contains processed (tone mapped) envmap, ready to load into the renderer """
+        self.envmap = None
+        """ Rotation of envmap along spherical (theta, phi) axes """
+        self.envmap_offset = [0.0, 0.0]
+
+        # IO
+        """ Path to a folder containing .hdr files """
+        self.folder = folder
+        """ List of available .hdr file names"""
+        self.available_envmaps = [option for option in self.FIXED_ENVMAP_OPTIONS]
+
+        if folder is not None:
+            self.available_envmaps += [f for f in os.listdir(folder) if f.lower().endswith('.hdr')]
+
+        self._last_update_details = dict()
+
+    def _load_hdr(self, envmap_name: Optional[str] = None) -> Optional[torch.Tensor]:
+        """Load an hdr environment map from the folder.
+        The loaded environment map updates the `envmap` field of this class,
+        and returns it.
+
+        Args:
+            envmap_name: Optional name of specific envmap to load. If None, No envmap is set.
+        """
+        if not self.available_envmaps or envmap_name in self.FIXED_ENVMAP_OPTIONS:
+            self.envmap = None
+            return
+
+        # If no specific envmap requested, use first one
+        if envmap_name not in self.available_envmaps:
+            raise ValueError(f"Environment map {self.folder}{os.path.sep}{envmap_name} not found.")
+
+        # Only reload HDR if it's a different file
+        if envmap_name != self.current_name:
+            envmap_path = os.path.join(self.folder, envmap_name)
+
+            try:
+                self._hdr_data = imageio.v2.imread(envmap_path, format='HDR-FI')
+            except RuntimeError:
+                # HDR loading requires a plugin: download the FreeImage library if missing
+                fi.download()
+                self._hdr_data = imageio.v2.imread(envmap_path, format='HDR-FI')
+            self._update()   # Updates self.envmap in place
+
+        return self.envmap
+
+    def set_env(self, env_name: Optional[str] = None) -> None:
+        if env_name == 'Model-Background':
+            self._hdr_data = None
+            self.envmap = torch.zeros([512, 512, 4], dtype=torch.float32, device=self.device)
+        elif env_name == 'Black':
+            self._hdr_data = None
+            self.envmap = torch.zeros([512, 512, 4], dtype=torch.float32, device=self.device)
+        elif env_name == 'White':
+            self._hdr_data = None
+            self.envmap = torch.ones([512, 512, 4], dtype=torch.float32, device=self.device)
+        else:
+            self.envmap = self._load_hdr(env_name)
+        self.current_name = env_name
+
+    def _update(self) -> None:
+        """Update the processed environment map based on current settings."""
+        if self._hdr_data is None:
+            return
+        # Apply exposure
+        hdr = np.maximum(0, self._hdr_data * self.ibl_intensity)
+        # Pad to a 4 channel texture because CUDA does not support 3 channels textures
+        envmap = torch.tensor(hdr, device=self.device, dtype=torch.float32)
+        pad = envmap.new_ones(envmap.shape[0], envmap.shape[1], 1)
+        self.envmap = torch.cat([envmap, pad], dim=-1)
+
+    def tonemap(self, hdr):
+
+        hdr *= 2**self.exposure
+
+        if self.tonemapper == 'Filmic':
+            # Apply filmic tonemapping, assumed to be used by polyhaven
+            A, B, C, D, E, F = 0.22, 0.30, 0.10, 0.20, 0.01, 0.30
+
+            def filmic_curve(x):
+                return ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F
+
+            white_scale = filmic_curve(11.2)
+            ldr = filmic_curve(hdr) / white_scale
+
+        elif self.tonemapper == 'Reinhard':
+            epsilon = 1e-6
+            key = 0.18
+            luminance = 0.2126 * hdr[:, :, 0] + 0.7152 * hdr[:, :, 1] + 0.0722 * hdr[:, :, 2]
+            log_average_luminance = torch.exp(torch.mean(torch.log(epsilon + luminance)))
+            scaled_luminance = key / log_average_luminance * luminance
+            tone_mapped_luminance = scaled_luminance / (1.0 + scaled_luminance)
+            ldr = hdr * (tone_mapped_luminance / (luminance + epsilon)).unsqueeze(2)
+        elif self.tonemapper == 'None' or self.tonemapper is None:
+            ldr = hdr
+        else:
+            raise ValueError(f"Invalid tonemapper. Must be one of {self.TONEMAPPER_OPTIONS}")
+
+        # Clean up any NaN values
+        ldr = torch.nan_to_num(ldr)
+        return ldr
+
+    def get_envmap(self) -> torch.Tensor:
+        if self._is_dirty():
+            self._update()
+            self._cache_last_update_details()
+        return self.envmap
+
+    def get_envmap_offset(self) -> torch.Tensor:
+        return torch.tensor(self.envmap_offset)
+
+    def _cache_last_update_details(self) -> None:
+        if self.envmap is None:
+            self._last_update_details = dict()
+        else:
+            self._last_update_details = dict(
+                current_name=self.current_name,
+                tonemapper=self.tonemapper,
+                ibl_intensity=self.ibl_intensity,
+                exposure=self.exposure,
+                envmap_offset=self.envmap_offset
+            )
+
+    def _is_dirty(self):
+        return (
+            self._last_update_details.get('current_name') != self.current_name or
+            self._last_update_details.get('tonemapper') != self.tonemapper or
+            self._last_update_details.get('ibl_intensity') != self.exposure or
+            self._last_update_details.get('exposure') != self.exposure or
+            self._last_update_details.get('envmap_offset') != self.envmap_offset
+        )
+
+    def is_ignore_envmap(self):
+        return self.current_name == 'Model-Background'

--- a/threedgrut_playground/utils/video_out.py
+++ b/threedgrut_playground/utils/video_out.py
@@ -20,16 +20,6 @@ import cv2
 from tqdm import tqdm
 from scipy.interpolate import splprep, splev
 from kaolin.render.camera import Camera
-from threedgrut.utils.logger import logger
-from threedgrut.model.model import MixtureOfGaussians
-from threedgrut.model.background import BackgroundColor
-from threedgrut_playground.utils.mesh_io import load_mesh, load_materials, load_missing_material_info, create_procedural_mesh
-from threedgrut_playground.utils.depth_of_field import DepthOfField
-from threedgrut_playground.utils.spp import SPP
-from threedgrut_playground.tracer import Tracer
-from threedgrut_playground.utils.kaolin_future.transform import ObjectTransform
-from threedgrut_playground.utils.kaolin_future.conversions import polyscope_from_kaolin_camera, polyscope_to_kaolin_camera
-from threedgrut_playground.utils.kaolin_future.fisheye import generate_fisheye_rays
 from threedgrut_playground.utils.kaolin_future.interpolated_cameras import camera_path_generator
 
 


### PR DESCRIPTION
Updates Playground with support for meshes with Physically Based Rendering materials.
Since Cook Torrance shading requires a light source, additional features are introduced in this PR:
* Better support for PBR textures, and attenuating them them through the material menu
* Envmaps - for global light
* HDR can be scaled up and down, to better align with Gaussian Spherical Harmonics
* Tonemapping, post rendering
* The path tracer supports BRDF and BTDF - e.g. meshes with transmissive materials