### PR TITLE
Fix mismatched computeMeshFaceBuffer defination

### DIFF
--- a/threedgrut_playground/include/playground/meshBuffers.h
+++ b/threedgrut_playground/include/playground/meshBuffers.h
@@ -18,8 +18,8 @@
 #include <optix.h>
 
 void computeMeshFaceBuffer(uint32_t fNum,
-                           const float3* __restrict__ verts,
-                           const int3* __restrict__ faces,
+                           const float3* verts,
+                           const int3* faces,
                            float3* fPrimVrt,
                            int3* fPrimTri,
                            cudaStream_t stream);

--- a/threedgrut_playground/src/meshBuffers.cu
+++ b/threedgrut_playground/src/meshBuffers.cu
@@ -33,8 +33,8 @@ inline __host__ uint32_t div_round_up(uint32_t val, uint32_t divisor) {
 
 __global__ void computeMeshFaceBufferKernel(
     const uint32_t fNum,
-    const float3* verts,
-    const int3* faces,
+    const float3* __restrict__ verts,
+    const int3* __restrict__ faces,
     float3* __restrict__ fPrimVrt,
     int3* __restrict__ fPrimTri) {
 


### PR DESCRIPTION
Fixes for https://github.com/nv-tlabs/3dgrut/issues/103 and https://github.com/nv-tlabs/3dgrut/issues/103

