### PR TITLE
Fix dependency conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ rich
 slangtorch==1.3.4
 # NeRF Dataset requirements
 kornia
-opencv-python
+opencv-python<4.12.0  # because of our numpy<2.0 requirement
 einops
 imageio
 msgpack


### PR DESCRIPTION
Latest `opencv-python` starts to require `numpy>2.0`, so cap the version until we can have `numpy>2.0` requirement dropped.