### PR TITLE
Fix ScannetppDataset intrinsics iteration after dict refactor

### DIFF
--- a/threedgrut/datasets/dataset_scannetpp.py
+++ b/threedgrut/datasets/dataset_scannetpp.py
@@ -41,7 +41,7 @@ class ScannetppDataset(ColmapDataset):
         self.cam_intrinsics = read_colmap_intrinsics_text(cameras_intrinsic_file)
 
         # Remove camera distortions because images are already undistorted
-        for intr in self.cam_intrinsics:
+        for intr in self.cam_intrinsics.values():
             intr.params[4:] = 0.0
 
     def get_images_folder(self):


### PR DESCRIPTION
## Problem
ScannetppDataset fails to load with `AttributeError: 'int' object has no attribute 'params'` after recent changes to dataset_colmap.py that converted `cam_intrinsics` from a list to a dictionary.

## Root Cause
- `dataset_colmap.py` was updated to store `cam_intrinsics` as `dict[camera_id, intrinsic_object]`
- `ScannetppDataset.load_intrinsics_and_extrinsics()` still assumed it was a list
- When iterating `for intr in self.cam_intrinsics:`, it now iterates over dictionary keys (integers) instead of camera objects

## Solution
Change iteration to `for intr in self.cam_intrinsics.values():` to access the actual camera intrinsic objects.

## Testing
- [x] Fixes the AttributeError when loading ScannetppDataset
- [x] Maintains expected behavior of setting `intr.params[4:] = 0.0`
- [x] No breaking changes to existing functionality
