### PR TITLE
Fix undefined iJIT_NotifyEvent

### DIFF
--- a/install_env.sh
+++ b/install_env.sh
@@ -125,7 +125,7 @@ conda activate $CONDA_ENV
 if [ "$CUDA_VERSION" = "11.8.0" ]; then
     echo "Installing CUDA 11.8.0 ..."
     conda install -y cuda-toolkit cmake ninja -c nvidia/label/cuda-11.8.0
-    conda install -y pytorch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 pytorch-cuda=11.8 "numpy<2.0" -c pytorch -c nvidia/label/cuda-11.8.0
+    conda install -y pytorch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 pytorch-cuda=11.8 "numpy<2.0" "mkl<=2022.1.0" -c pytorch -c nvidia/label/cuda-11.8.0
     pip3 install --find-links https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.1.2_cu118.html kaolin==0.17.0
 
 # CUDA 12.8 supports compute capability 10.0 and 12.0


### PR DESCRIPTION
Encountered this error 
```
229.0 Preparing transaction: done                    
229.1 Verifying transaction: done                    
229.2 Executing transaction: done                    
229.9 Collecting git+https://github.com/rahul-goel/fused-ssim@1272e21a282342e89537159e4bad508b19b34157 (from -r requirements.txt (line 23))
229.9   Cloning https://github.com/rahul-goel/fused-ssim (to revision 1272e21a282342e89537159e4bad508b19b34157) to /tmp/pip-req-build-q_zrk9gd
229.9   Running command git clone --filter=blob:none --quiet https://github.com/rahul-goel/fused-ssim /tmp/pip-req-build-q_zrk9gd
230.9   Running command git rev-parse -q --verify 'sha^1272e21a282342e89537159e4bad508b19b34157'
230.9   Running command git fetch -q https://github.com/rahul-goel/fused-ssim 1272e21a282342e89537159e4bad508b19b34157
231.2   Running command git checkout -q 1272e21a282342e89537159e4bad508b19b34157
231.6   Resolved https://github.com/rahul-goel/fused-ssim to commit 1272e21a282342e89537159e4bad508b19b34157
231.6   Preparing metadata (setup.py): started
231.8   Preparing metadata (setup.py): finished with status 'error'
231.8   error: subprocess-exited-with-error
231.8   
231.8   × python setup.py egg_info did not run successfully.
231.8   │ exit code: 1
231.8   ╰─> [9 lines of output]
231.8       Traceback (most recent call last):
231.8         File "<string>", line 2, in <module>
231.8         File "<pip-setuptools-caller>", line 35, in <module>
231.8         File "/tmp/pip-req-build-q_zrk9gd/setup.py", line 2, in <module>
231.8           from torch.utils.cpp_extension import CUDAExtension, BuildExtension
231.8         File "/opt/conda/envs/3dgrut/lib/python3.11/site-packages/torch/__init__.py", line 235, in <module>
231.8           from torch._C import *  # noqa: F403
231.8           ^^^^^^^^^^^^^^^^^^^^^^
231.8       ImportError: /opt/conda/envs/3dgrut/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so: undefined symbol: iJIT_NotifyEvent
231.8       [end of output]
231.8   
231.8   note: This error originates from a subprocess, and is likely not a problem with pip.
231.8 error: metadata-generation-failed
231.8 
231.8 × Encountered error while generating package metadata.
231.8 ╰─> See above for output.
231.8 
231.8 note: This is an issue with the package mentioned above, not pip.
231.8 hint: See above for details.
```

Fix by limiting MKL version.

Reference: https://github.com/pytorch/pytorch/issues/123097