### PR TITLE
fix shell shebang for install script

### DIFF
--- a/install_env.sh
+++ b/install_env.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -13,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
 
 # Exit on error
 set -e


### PR DESCRIPTION
The shell command got bumped by the copyright comment to no longer be the first line of the file. It doesn't work unless it's the first line of the file, so this can cause the script to run with the wrong shell, yielding confusing errors.