### PR TITLE
Allow passing fused point cloud in the training

### DIFF
--- a/configs/apps/cusfm_3dgut.yaml
+++ b/configs/apps/cusfm_3dgut.yaml
@@ -2,7 +2,7 @@
 
 # order in which configs override each other (/* - denotes a relative search path)
 defaults:
-  - /base_mcmc
+  - /base_gs
   - /dataset: colmap
   - /initialization: fused_point_cloud
   - /render: 3dgut
@@ -10,6 +10,7 @@ defaults:
 
 # overwrite of default parameters
 val_frequency: 999999 # never validate
+
 
 initialization:
   fused_point_cloud_path: ???  # Path to fused point cloud PLY file to be provided by user at runtime

--- a/configs/initialization/accumulated_point_cloud.yaml
+++ b/configs/initialization/accumulated_point_cloud.yaml
@@ -1,5 +1,0 @@
-method: accumulated_point_cloud
-observation_scale_factor: 0.01
-use_observation_points: true
-accumulated_point_cloud_path: ???  # Path to accumulated point cloud PLY file
-

--- a/configs/initialization/fused_point_cloud.yaml
+++ b/configs/initialization/fused_point_cloud.yaml
@@ -1,0 +1,5 @@
+method: fused_point_cloud
+observation_scale_factor: 0.01
+use_observation_points: false
+fused_point_cloud_path: ???  # Path to fused point cloud PLY file
+

--- a/threedgrut/datasets/utils.py
+++ b/threedgrut/datasets/utils.py
@@ -479,7 +479,11 @@ def read_colmap_extrinsics_text(path):
     with open(path, "r") as fid:
         # Skip comment lines and get valid lines
         lines = (line.strip() for line in fid)
-        # lines = (line for line in lines if line and not line.startswith("#"))
+        # This update handles cases in images.txt where no 2D points are associated with an image.
+        # In such cases, some entries contain only:
+        # IMAGE_ID, QW, QX, QY, QZ, TX, TY, TZ, CAMERA_ID, NAME
+        # and do not include the usual POINTS2D[] line (which normally lists (X, Y, POINT3D_ID)).
+        # The following logic checks for missing points line and handles it properly:
         lines = (line for line in lines if line == "" or not line.startswith("#"))
         # Process lines in pairs (image info + points info)
         try:

--- a/threedgrut/model/model.py
+++ b/threedgrut/model/model.py
@@ -252,55 +252,44 @@ class MixtureOfGaussians(torch.nn.Module, ExportableModel):
             file_pts, observer_pts, file_rgb, use_observer_pts=self.conf.initialization.use_observation_points
         )
 
-    def init_from_accumulated_point_cloud(self, pc_path: str, observer_pts):
+    def init_from_fused_point_cloud(self, pc_path: str, observer_pts):
         """
-        Initialize gaussians from an accumulated point cloud PLY file.
+        Initialize gaussians from an fused point cloud PLY file.
         Similar to init_from_colmap but loads from a given PLY file instead of sparse/0/points3D.txt
-        
+
         Args:
             pc_path: Path to the PLY point cloud file
             observer_pts: Observer points tensor for scale initialization
         """
-        logger.info(f"Loading accumulated point cloud from {pc_path}...")
-        
+        logger.info(f"Loading fused point cloud from {pc_path}...")
+
         # Read PLY file
         plydata = PlyData.read(pc_path)
-        vertices = plydata['vertex']
-        
+        vertices = plydata["vertex"]
+
         # Extract XYZ coordinates
-        xyz = np.stack([
-            vertices['x'],
-            vertices['y'],
-            vertices['z']
-        ], axis=1).astype(np.float32)
-        
+        xyz = np.stack([vertices["x"], vertices["y"], vertices["z"]], axis=1).astype(np.float32)
+
         # Extract RGB colors (check if they exist)
-        if 'red' in vertices and 'green' in vertices and 'blue' in vertices:
-            rgb = np.stack([
-                vertices['red'],
-                vertices['green'],
-                vertices['blue']
-            ], axis=1).astype(np.uint8)
+        if "red" in vertices and "green" in vertices and "blue" in vertices:
+            rgb = np.stack([vertices["red"], vertices["green"], vertices["blue"]], axis=1).astype(np.uint8)
         else:
             # If no colors, initialize with random colors
             logger.warning("No RGB data found in point cloud, using random colors")
             rgb = np.random.randint(0, 256, size=(len(vertices), 3), dtype=np.uint8)
-        
+
         # Convert to torch tensors
         file_pts = torch.tensor(xyz, dtype=torch.float32, device=self.device)
         file_rgb = torch.tensor(rgb, dtype=torch.uint8, device=self.device)
-        
+
         logger.info(f"Loaded {len(file_pts)} points from accumulated point cloud")
-        
+
         # Initialize using the same method as COLMAP
         assert file_rgb.dtype == torch.uint8, "Expecting RGB values to be in [0, 255] range"
         self.default_initialize_from_points(
-            file_pts, 
-            observer_pts, 
-            file_rgb, 
-            use_observer_pts=self.conf.initialization.use_observation_points
+            file_pts, observer_pts, file_rgb, use_observer_pts=self.conf.initialization.use_observation_points
         )
-        
+
     def init_from_pretrained_point_cloud(self, pc_path: str, set_optimizable_parameters: bool = True):
         data = PlyData.read(pc_path)
         num_gaussians = len(data["vertex"])

--- a/threedgrut/trainer.py
+++ b/threedgrut/trainer.py
@@ -256,13 +256,13 @@ class Trainer3DGRUT:
                         train_dataset.get_observer_points(), dtype=torch.float32, device=self.device
                     )
                     model.init_from_colmap(conf.path, observer_points)
-                case "accumulated_point_cloud":
+                case "fused_point_cloud":
                     observer_points = torch.tensor(
                         train_dataset.get_observer_points(), dtype=torch.float32, device=self.device
                     )
-                    ply_path = conf.initialization.accumulated_point_cloud_path
+                    ply_path = conf.initialization.fused_point_cloud_path
                     logger.info(f"Initializing from accumulated point cloud: {ply_path}")
-                    model.init_from_accumulated_point_cloud(ply_path, observer_points)
+                    model.init_from_fused_point_cloud(ply_path, observer_points)
                 case "point_cloud":
                     try:
                         ply_path = os.path.join(conf.path, "point_cloud.ply")


### PR DESCRIPTION
## **Summary**

This merge request adds support for **fused point cloud initialization** .

---
###  **Features Added**

* **Fused Point Cloud Initialization**
  Introduced a new initialization method, `fused_point_cloud`, enabling initialization of 3D Gaussians from a  point cloud (`.ply`   file).

* **cuSFM Output Adaptation**
Modified the line parsing logic in function `read_colmap_extrinsics_text ` to handle cuSFM’s `images.txt` format, where some images contain only the line
 `IMAGE_ID, QW, QX, QY, QZ, TX, TY, TZ, CAMERA_ID, NAME`
and do **not** include the `POINTS2D[]` line (which normally contains `(X, Y, POINT3D_ID)`).


  ```python
  # Original
  lines = (line for line in lines if line and not line.startswith("#"))

  # Updated
  lines = (line for line in lines if line == "" or not line.startswith("#"))
  ```

---

###  **Config Files Using Accumulated Point Cloud Initialization**

* Added `configs/apps/cusfm_3dgut_mcmc.yaml` — configuration for accumulated point cloud–based training.
* Added `configs/initialization/accumulated_point_cloud.yaml` — defines parameters for point cloud initialization:

  * `observation_scale_factor: 0.01`
  * `use_observation_points: true`
  * `accumulated_point_cloud_path`: configurable path to the input `.ply` file
  
###  **Commands to train 3DGRUT using a given point cloud for initialization**
```
  python train.py \
    --config-name apps/cusfm_3dgut_mcmc.yaml \
    path=<path_to_cuSFM> \
    out_dir=<path_to_out> \  
    initialization.accumulated_point_cloud_path=<path_to_nvblox_dir>/nvblox_mesh.ply \
    experiment_name=3dgut_mcmc \
    export_usdz.enabled=true \
    export_usdz.apply_normalizing_transform=true
```

