### PR TITLE
Fix PPISP controller distillation; Add use_controller flag

### DIFF
--- a/configs/base_gs.yaml
+++ b/configs/base_gs.yaml
@@ -124,6 +124,9 @@ loss:
 # Post-processing configuration
 post_processing:
   method: null # Possible values: null, "ppisp"
+  # Enable the controller for predicting per-frame corrections for novel views.
+  # When false, zero corrections are used for novel views.
+  use_controller: true
   # Number of extra distillation steps after main training (only for "ppisp").
   # When > 0, enables distillation mode: Gaussians and PPISP params are frozen,
   # only the controller is trained for these additional steps.

--- a/threedgrut/render.py
+++ b/threedgrut/render.py
@@ -123,17 +123,21 @@ class Renderer:
             from ppisp import PPISP, PPISPConfig
 
             # Derive config from training settings to match trainer.py
+            use_controller = conf.post_processing.get("use_controller", True)
             n_distillation_steps = conf.post_processing.get("n_distillation_steps", 5000)
-            if n_distillation_steps > 0:
+            if use_controller and n_distillation_steps > 0:
                 main_training_steps = conf.n_iterations - n_distillation_steps
                 controller_activation_ratio = main_training_steps / conf.n_iterations
                 controller_distillation = True
-            else:
+            elif use_controller:
                 controller_activation_ratio = 0.8
+                controller_distillation = False
+            else:
+                controller_activation_ratio = 0.0
                 controller_distillation = False
 
             ppisp_config = PPISPConfig(
-                use_controller=True,
+                use_controller=use_controller,
                 controller_distillation=controller_distillation,
                 controller_activation_ratio=controller_activation_ratio,
             )

--- a/threedgrut/strategy/base.py
+++ b/threedgrut/strategy/base.py
@@ -24,6 +24,15 @@ class BaseStrategy:
     def __init__(self, config, model: MixtureOfGaussians) -> None:
         self.conf = config
         self.model = model
+        self._suspended = False
+
+    def suspend(self) -> None:
+        """Suspend the strategy, causing all training callbacks to no-op.
+
+        Used during PPISP controller distillation to prevent densification, pruning, and other
+        parameter mutations while Gaussian parameters are frozen.
+        """
+        self._suspended = True
 
     def init_densification_buffer(self, checkpoint: Optional[dict] = None):
         """Callback function to initialize the densification buffers."""
@@ -31,14 +40,29 @@ class BaseStrategy:
 
     def pre_backward(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
         """Callback function to be executed before the `loss.backward()` call."""
+        if self._suspended:
+            return False
+        return self._pre_backward(step, scene_extent, train_dataset, batch, writer)
+
+    def _pre_backward(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
         return False
 
     def post_backward(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
         """Callback function to be executed after the `loss.backward()` call."""
+        if self._suspended:
+            return False
+        return self._post_backward(step, scene_extent, train_dataset, batch, writer)
+
+    def _post_backward(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
         return False
 
     def post_optimizer_step(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
         """Callback function to be executed after the optimizer step."""
+        if self._suspended:
+            return False
+        return self._post_optimizer_step(step, scene_extent, train_dataset, batch, writer)
+
+    def _post_optimizer_step(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
         return False
 
     def update_gradient_buffer(self, sensor_position: torch.Tensor) -> None:

--- a/threedgrut/strategy/gs.py
+++ b/threedgrut/strategy/gs.py
@@ -56,7 +56,7 @@ class GSStrategy(BaseStrategy):
             self.densify_grad_norm_accum = torch.zeros((num_gaussians, 1), dtype=torch.float, device=self.model.device)
             self.densify_grad_norm_denom = torch.zeros((num_gaussians, 1), dtype=torch.int, device=self.model.device)
 
-    def post_backward(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
+    def _post_backward(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
         """Callback function to be executed after the `loss.backward()` call."""
 
         # Update densification buffer:
@@ -71,8 +71,8 @@ class GSStrategy(BaseStrategy):
 
         return False
 
-    def post_optimizer_step(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
-        """Callback function to be executed after the `loss.backward()` call."""
+    def _post_optimizer_step(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
+        """Callback function to be executed after the optimizer step."""
         scene_updated = False
         # Densify the Gaussians
 

--- a/threedgrut/strategy/mcmc.py
+++ b/threedgrut/strategy/mcmc.py
@@ -76,7 +76,7 @@ class MCMCStrategy(BaseStrategy):
             device=self.model.device,
         )
 
-    def post_optimizer_step(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
+    def _post_optimizer_step(self, step: int, scene_extent: float, train_dataset, batch=None, writer=None) -> bool:
         # Relocate dead gaussians to the alive areas
         if check_step_condition(
             step,

--- a/threedgrut/trainer.py
+++ b/threedgrut/trainer.py
@@ -341,22 +341,28 @@ class Trainer3DGRUT:
             num_cameras = len(frames_per_camera)
             num_frames = sum(frames_per_camera)
 
+            use_controller = conf.post_processing.get("use_controller", True)
+
             # Distillation mode: controller activates after main training
             # Total iterations = n_iterations, distillation starts at n_iterations - n_distillation_steps
             n_distillation_steps = conf.post_processing.get("n_distillation_steps", 5000)
-            if n_distillation_steps > 0:
+            if use_controller and n_distillation_steps > 0:
                 main_training_steps = conf.n_iterations - n_distillation_steps
                 controller_activation_ratio = main_training_steps / conf.n_iterations
                 controller_distillation = True
                 self._distillation_start_step = main_training_steps
                 logger.info(f"📷 PPISP distillation mode: controller activates at step {main_training_steps}")
-            else:
+            elif use_controller:
                 controller_activation_ratio = 0.8
                 controller_distillation = False
-                self._distillation_start_step = None
+                self._distillation_start_step = -1
+            else:
+                controller_activation_ratio = 0.0
+                controller_distillation = False
+                self._distillation_start_step = -1
 
             ppisp_config = PPISPConfig(
-                use_controller=True,
+                use_controller=use_controller,
                 controller_distillation=controller_distillation,
                 controller_activation_ratio=controller_activation_ratio,
             )
@@ -846,9 +852,10 @@ class Trainer3DGRUT:
             if self.global_step >= conf.n_iterations:
                 return
 
-            # Freeze Gaussians when distillation starts
+            # Freeze Gaussians and suspend strategy when distillation starts
             if self._distillation_start_step >= 0 and self.global_step >= self._distillation_start_step:
                 self.model.freeze_gaussians()
+                self.strategy.suspend()
 
             # Access the GPU-cache batch data
             gpu_batch = self.train_dataset.get_gpu_batch_with_intrinsics(batch)


### PR DESCRIPTION
- Add suspension for GS and MCMC strategies. This is required for PPISP controller distillation. This worked with MCMC "by chance" already before, but this new fix is more principled.
- Expose the `use_controller` flag from the PPISP config so the controller can be disabled entirely.