### PR TITLE
Fix sphere primitive center/radius buffer allocation

### DIFF
--- a/threedgrt_tracer/src/optixTracer.cpp
+++ b/threedgrt_tracer/src/optixTracer.cpp
@@ -727,7 +727,8 @@ void OptixTracer::buildBVH(torch::Tensor mogPos,
         } else if (_state->gPrimType == MOGTracingSphere) {
             _state->gPrimNumVert = 0;
             _state->gPrimNumTri  = 1; // number of primtive per gaussians
-            reallocatePrimGeomBuffer(cudaStream);
+            reallocateBuffer(&_state->gPrimVrt, _state->gPrimVrtSz, sizeof(float3) * gNum, cudaStream);
+            reallocateBuffer(&_state->gPrimTri, _state->gPrimTriSz, sizeof(float) * gNum, cudaStream);
 
             computeGaussianEnclosingSphere(gNum,
                                            getPtr<float3>(mogPos),


### PR DESCRIPTION
Fixes the sphere primitive BVH build path, which was allocating incorrect buffers and could trigger `cudaErrorIllegalAddress`

### Changes

- special-case sphere buffer allocation in `MOGTracingSphere`
- allocate center storage as `float3[gNum]`
- allocate radius storage as `float[gNum]`


### Validation
- reproduced the crash with `render.primitive_type=sphere`
- verified the patched path no longer hits the same illegal memory access and runs with no error

Closes #209 