### PR TITLE
fix(trainer): Move GUI imports inside conditional statements, add viser in dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ omegaconf
 hydra-core
 scikit-learn
 wandb
-polyscope>=2.3.0
 addict
 rich
 slangtorch==1.3.18
@@ -37,3 +36,6 @@ simplejpeg
 # formatter
 black==25.9.0
 isort==5.13.0
+# graphics user interfaces
+polyscope>=2.3.0
+viser

--- a/threedgrut/trainer.py
+++ b/threedgrut/trainer.py
@@ -38,12 +38,10 @@ from threedgrut.model.model import MixtureOfGaussians
 from threedgrut.optimizers import SelectiveAdam
 from threedgrut.render import Renderer
 from threedgrut.strategy.base import BaseStrategy
-from threedgrut.utils.gui import GUI
 from threedgrut.utils.logger import logger
 from threedgrut.utils.misc import check_step_condition, create_summary_writer, jet_map
 from threedgrut.utils.render import apply_post_processing
 from threedgrut.utils.timer import CudaTimer
-from threedgrut.utils.viser_gui_util import ViserGUI
 
 
 class Trainer3DGRUT:
@@ -330,9 +328,14 @@ class Trainer3DGRUT:
     ):
         gui = None
         if conf.with_gui:
+            from threedgrut.utils.gui import GUI
+
             gui = GUI(conf, model, train_dataset, val_dataset, scene_bbox)
         elif conf.with_viser_gui:
+            from threedgrut.utils.viser_gui_util import ViserGUI
+
             gui = ViserGUI(conf, model, train_dataset, val_dataset, scene_bbox)
+
         self.gui = gui
 
     def init_metrics(self):


### PR DESCRIPTION
This change optimizes the import structure by moving the GUI-related imports into the conditional blocks where they are used. This helps to reduce unnecessary imports when the GUI is not required, improving the overall efficiency of the code. The refactor maintains the same functionality while enhancing code clarity.

Also adding viser into requirements.txt as a dependency