### PR TITLE
fix(dataset): read cx/cy from COLMAP PINHOLE intrinsics instead of de…

### DIFF
--- a/configs/apps/cusfm_3dgut_mcmc.yaml
+++ b/configs/apps/cusfm_3dgut_mcmc.yaml
@@ -13,3 +13,21 @@ val_frequency: 999999 # never validate
 
 initialization:
   fused_point_cloud_path: ???  # Path to fused point cloud PLY file to be provided by user at runtime
+
+model:
+  background:
+    color: white
+
+post_processing:
+  method: ppisp
+
+loss:
+  lambda_opacity: 0.0001
+  lambda_scale: 0.005
+
+strategy:
+  perturb:
+    noise_lr: 5000
+    end_iteration: 30000
+  add:
+    max_n_gaussians: 2300000

--- a/threedgrut/datasets/dataset_colmap.py
+++ b/threedgrut/datasets/dataset_colmap.py
@@ -148,7 +148,9 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
     def _store_camera_params_cpu(self):
         """Store camera parameters on CPU for multiprocessing compatibility."""
 
-        def create_pinhole_camera(focalx, focaly, w, h):
+        def create_pinhole_camera(focalx, focaly, w, h, cx=None, cy=None):
+            cx = cx if cx is not None else w / 2.0
+            cy = cy if cy is not None else h / 2.0
             # Generate UV coordinates
             u = np.tile(np.arange(w), h)
             v = np.arange(h).repeat(w)
@@ -156,13 +158,13 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
             params = OpenCVPinholeCameraModelParameters(
                 resolution=np.array([w, h], dtype=np.uint64),
                 shutter_type=ShutterType.GLOBAL,
-                principal_point=np.array([w, h], dtype=np.float32) / 2,
+                principal_point=np.array([cx, cy], dtype=np.float32),
                 focal_length=np.array([focalx, focaly], dtype=np.float32),
                 radial_coeffs=np.zeros((6,), dtype=np.float32),
                 tangential_coeffs=np.zeros((2,), dtype=np.float32),
                 thin_prism_coeffs=np.zeros((4,), dtype=np.float32),
             )
-            rays_o_cam, rays_d_cam = pinhole_camera_rays(u, v, focalx, focaly, w, h, self.ray_jitter)
+            rays_o_cam, rays_d_cam = pinhole_camera_rays(u, v, focalx, focaly, w, h, self.ray_jitter, cx=cx, cy=cy)
             pixel_coords = create_pixel_coords(w, h)
             return (
                 params.to_dict(),
@@ -241,12 +243,20 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
 
             if intr.model == "SIMPLE_PINHOLE":
                 focal_length = intr.params[0] / scaling_factor
-                self.intrinsics[intr.id] = create_pinhole_camera(focal_length, focal_length, width, height)
+                cx = intr.params[1] / scaling_factor
+                cy = intr.params[2] / scaling_factor
+                self.intrinsics[intr.id] = create_pinhole_camera(
+                    focal_length, focal_length, width, height, cx=cx, cy=cy
+                )
 
             elif intr.model == "PINHOLE":
                 focal_length_x = intr.params[0] / scaling_factor
                 focal_length_y = intr.params[1] / scaling_factor
-                self.intrinsics[intr.id] = create_pinhole_camera(focal_length_x, focal_length_y, width, height)
+                cx = intr.params[2] / scaling_factor
+                cy = intr.params[3] / scaling_factor
+                self.intrinsics[intr.id] = create_pinhole_camera(
+                    focal_length_x, focal_length_y, width, height, cx=cx, cy=cy
+                )
 
             elif intr.model == "OPENCV_FISHEYE":
                 params = copy.deepcopy(intr.params)

--- a/threedgrut/datasets/utils.py
+++ b/threedgrut/datasets/utils.py
@@ -58,7 +58,7 @@ def create_pixel_coords(width: int, height: int, device: torch.device = None) ->
     return torch.stack([pixel_x, pixel_y], dim=-1).unsqueeze(0)  # [1, H, W, 2]
 
 
-def pinhole_camera_rays(x, y, f_x, f_y, w, h, ray_jitter=None):
+def pinhole_camera_rays(x, y, f_x, f_y, w, h, ray_jitter=None, cx=None, cy=None):
     """
     return:
         ray_origin (sz_y, sz_x, 3)
@@ -72,8 +72,13 @@ def pinhole_camera_rays(x, y, f_x, f_y, w, h, ray_jitter=None):
     else:
         jitter_xs = jitter_ys = 0.5
 
-    xs = ((x + jitter_xs) - 0.5 * w) / f_x
-    ys = ((y + jitter_ys) - 0.5 * h) / f_y
+    if cx is None:
+        cx = 0.5 * w
+    if cy is None:
+        cy = 0.5 * h
+
+    xs = ((x + jitter_xs) - cx) / f_x
+    ys = ((y + jitter_ys) - cy) / f_y
 
     ray_lookat = np.stack((xs, ys, np.ones_like(xs)), axis=-1)
     ray_origin = np.zeros_like(ray_lookat)


### PR DESCRIPTION
### **Title**

fix(dataset): correctly read principal point from COLMAP intrinsics

---

### **Description**

This PR fixes an issue in dataset parsing where the principal point (`cx`, `cy`) from COLMAP camera intrinsics was ignored.

Previously:

* **PINHOLE** (`[fx, fy, cx, cy]`): only `fx`, `fy` were used, with `cx`, `cy` incorrectly set to image center (`w/2`, `h/2`)
* **SIMPLE_PINHOLE** (`[f, cx, cy]`): `cx`, `cy` were ignored entirely

This introduced **systematic ray direction errors** proportional to the offset between the true principal point and the image center (e.g., ~43 px offset on a 1200 px image). As a result, Gaussians were forced to blur to compensate for cross-view inconsistencies.

---

### **Changes**

* Correctly parse and use `cx`, `cy` from:

  * `PINHOLE`
  * `SIMPLE_PINHOLE`
* Remove hardcoded assumption of principal point at image center
* Update `cusfm_3dgut_mcmc.yaml` with improved defaults for Isaac/robot scenes:

  * Enable PPISP post-processing
  * Tune MCMC parameters (noise, opacity, scale)

---

### **Comparison results using this change**
<img width="2255" height="1364" alt="image" src="https://github.com/user-attachments/assets/125dd6fc-8099-487a-ad72-07a1ba5b0d77" />


### **How to Run**

```bash
python train.py --config-name apps/cusfm_3dgut_mcmc.yaml \
    path=/mnt/datasets/debug/endeavor_andoria_l1/ \
    out_dir=/mnt/datasets/debug/endeavor_andoria_l1/result_3dgrut \
    initialization.fused_point_cloud_path=/mnt/datasets/debug/endeavor_andoria_l1/nvblox_mesh/nvblox_mesh.ply \
    experiment_name=3dgut_mcmc_scale005_cx_cy
```

This configuration:

- uses the corrected principal point values (`cx`, `cy`) from COLMAP intrinsics,
- applies tuned MCMC parameters,
- enables PPISP post-processing for Isaac robot scenes.

For more details on generating an nvblox mesh and creating 3D assets, refer to the Reconstruct Scenes from Stereo Camera Data [documentation](https://docs.nvidia.com/nurec/robotics/neural_reconstruction_stereo.html#step-5-neural-reconstruction-with-3dgrut).


