### PR TITLE
Update rebase_helper.sh to exclude .gitlab-ci.yml

### DIFF
--- a/rebase_helper.sh
+++ b/rebase_helper.sh
@@ -30,7 +30,7 @@ if [ -z "$TARGET" ]; then
 fi
 
 # Ignore certain files and directories due to git-lfs limitations
-ignore=':(exclude)assets/*.gif :(exclude).gitattributes'
+ignore=':(exclude)assets/*.gif :(exclude).gitattributes :(exclude).gitlab-ci.yml'
 
 # Iterate over commit history backward till the initial commit
 commit=$(git rev-parse HEAD)


### PR DESCRIPTION
This avoids accidently shipping gitlab CI files to Github