### PR TITLE
Fix 3DGRT Compilation

### DIFF
--- a/threedgrt_tracer/include/3dgrt/cuoptixMacros.h
+++ b/threedgrt_tracer/include/3dgrt/cuoptixMacros.h
@@ -67,5 +67,5 @@
 
 // NVRTC compiler options
 #define CUDA_NVRTC_OPTIONS                                                                                                                 \
-    "-std=c++14", "-arch", "compute_75", "-use_fast_math", "-lineinfo", "--extra-device-vectorization", "-default-device", "-rdc", "true", \
+    "-std=c++17", "-arch", "compute_75", "-use_fast_math", "-lineinfo", "--extra-device-vectorization", "-default-device", "-rdc", "true", \
         "-D__OPTIX__"

--- a/threedgrt_tracer/include/3dgrt/kernels/cuda/gaussianParticles.cuh
+++ b/threedgrt_tracer/include/3dgrt/kernels/cuda/gaussianParticles.cuh
@@ -18,6 +18,10 @@
 #include <3dgrt/mathUtils.h>
 #include <3dgrt/particleDensity.h>
 
+// Define integer types for NVRTC compatibility
+typedef int int32_t;
+typedef unsigned int uint32_t;
+
 void quaternionWXYZToMatrix(const float4& q, float33& ret) {
     const float r = q.x;
     const float x = q.y;


### PR DESCRIPTION
Update NVRTC compiler options to C++17 and define integer types for NVRTC compatibility in gaussianParticles.cuh

Related to https://github.com/nv-tlabs/3dgrut/issues/197
I am not too sure why I suddenly have issue with `int32_t` and `uint32_t` on one of my machines?