### PR TITLE
fix(3dgut): Fix CUDA compilation error when k_buffer_size > 0

### DIFF
--- a/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutRenderer.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/renderers/gutRenderer.cuh
@@ -114,6 +114,7 @@ __global__ void render(threedgut::RenderParameters params,
     finalizeRay(ray, params, sensorRayOriginPtr, worldHitCountPtr, worldHitDistancePtr, radianceDensityPtr, sensorToWorldTransform);
 }
 
+#if FINE_GRAINED_LOAD_BALANCING
 // Fine-grained load balancing rendering kernel: static allocation per virtual tile
 __global__ void renderBalanced(threedgut::RenderParameters params,
                                const tcnn::uvec2* __restrict__ sortedTileRangeIndicesPtr,
@@ -213,6 +214,7 @@ __global__ void renderBalanced(threedgut::RenderParameters params,
         }
     }
 }
+#endif // FINE_GRAINED_LOAD_BALANCING
 
 __global__ void renderBackward(threedgut::RenderParameters params,
                                const tcnn::uvec2* __restrict__ sortedTileRangeIndicesPtr,


### PR DESCRIPTION
Fix CUDA compilation error when k_buffer_size > 0 and fine_grained_load_balancing is disabled

The renderBalanced __global__ kernel was compiled unconditionally, causing a static_assert failure in evalForwardNoKBufferBalanced (which requires KHitBufferSize == 0). Wrap the kernel definition with #if FINE_GRAINED_LOAD_BALANCING to match the existing guard at the call site.