### PR TITLE
Update formatter.sh and pyproject.toml for improved formatting and dependency management

### DIFF
--- a/formatter.sh
+++ b/formatter.sh
@@ -27,7 +27,7 @@ pushd "$SCRIPT_DIR" &> /dev/null
 
 CLANG_FORMAT_REQUIRED_VERSION=18
 if command -v clang-format &> /dev/null; then
-    CLANG_FORMAT_VERSION=$(clang-format --version | grep -oP '\d+' | head -1)
+    CLANG_FORMAT_VERSION=$(clang-format --version | grep -oE '[0-9]+' | head -1)
     if [ "$CLANG_FORMAT_VERSION" -ne "$CLANG_FORMAT_REQUIRED_VERSION" ]; then
         echo "clang-format version $CLANG_FORMAT_VERSION detected, but version $CLANG_FORMAT_REQUIRED_VERSION is required."
         echo "Install with: pip3 install 'clang-format==18.*'"
@@ -52,11 +52,11 @@ else
 fi
 
 echo "$ACTION Python code with black..."
-black . "${BLACK_OPTS[@]}" --target-version=py311 --line-length=120 --extend-exclude=thirdparty/tiny-cuda-nn || FAILED=1
+black . ${BLACK_OPTS[@]+"${BLACK_OPTS[@]}"} --target-version=py311 --line-length=120 --extend-exclude=thirdparty/tiny-cuda-nn || FAILED=1
 echo ""
 
 echo "$ACTION Python code with isort..."
-isort . "${ISORT_OPTS[@]}" --skip-gitignore --dont-follow-links --extend-skip=thirdparty/tiny-cuda-nn --profile=black || FAILED=1
+isort . ${ISORT_OPTS[@]+"${ISORT_OPTS[@]}"} --skip-gitignore --dont-follow-links --extend-skip=thirdparty/tiny-cuda-nn --profile=black || FAILED=1
 echo ""
 
 popd &> /dev/null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
 dev = [
     "black==26.3.1",
     "isort==5.13.0",
+    "clang-format==18.1.8",
 ]
 gui = [
     "libigl",


### PR DESCRIPTION

- Changed regex in formatter.sh to use grep -oE for better compatibility.
- Updated black and isort commands to handle optional array expansions correctly.
- Added clang-format version 18.1.8 to pyproject.toml dependencies for consistency.