### PR TITLE
ship C++/CUDA extension sources and thirdparty headers in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,29 @@ playground = [
     "kaolin>=0.17.0",
 ]
 
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+# torch.utils.cpp_extension.load compiles the tracers at runtime, so the wheel must
+# ship their C++/CUDA sources and the tiny-cuda-nn headers they include: common.h,
+# common_host.h, cpp_api.h, vec.h, and the fmt/json/pybind11_json deps.
+"threedgut_tracer" = ["include/**/*", "src/**/*", "*.cpp"]
+"threedgrt_tracer" = ["include/**/*", "src/**/*", "*.cpp"]
+"thirdparty" = [
+  "tiny-cuda-nn/include/tiny-cuda-nn/common.h",
+  "tiny-cuda-nn/include/tiny-cuda-nn/common_host.h",
+  "tiny-cuda-nn/include/tiny-cuda-nn/cpp_api.h",
+  "tiny-cuda-nn/include/tiny-cuda-nn/vec.h",
+  "tiny-cuda-nn/dependencies/fmt/include/**/*",
+  "tiny-cuda-nn/dependencies/json/**/*",
+  "tiny-cuda-nn/dependencies/pybind11_json/**/*",
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["threedgrut*", "threedgrt_tracer*", "threedgut_tracer*", "threedgrut_playground*"]
-exclude = ["thirdparty*", ".venv*"]
+include = ["threedgrut*", "threedgrt_tracer*", "threedgut_tracer*", "threedgrut_playground*", "thirdparty*"]
+exclude = [".venv*"]
 
 [tool.uv.sources]
 torch = { index = "pytorch" }


### PR DESCRIPTION
The wheel ships no .cu/.cuh/.cpp/.slang sources and no thirdparty/ headers, so torch.utils.cpp_extension.load can't build lib3dgut_cc / lib3dgrt_cc on a non-editable install

This works for the editable install because the source tree is right there on disk but `pip install` / `uv add` from a git or pypi source produces a wheel that can't build lib3dgut_cc at runtime via torch.utils.cpp_extension.load

How we consume threedgrut downstream (the path that originally hit the missing headers):
```toml
      dependencies = [
          "threedgrut",
          "torch",
          "ninja",
      ]

      [tool.uv.sources]
      threedgrut = { git = "https://github.com/commaai/3dgrut.git", rev = "<our-fork-sha>" }

      [tool.uv]
      # threedgrut's own pyproject lists heavy deps (kaolin, hydra, etc.) we don't use.
      # Override to install threedgrut alone; with the package-data globs this PR adds,
      # the wheel ships everything torch.utils.cpp_extension.load needs at runtime.
      dependency-metadata = [
          { name = "threedgrut", version = "0.0.2", requires-dist = [], requires-python = ">=3.11" },
      ]

```

If toml can include package-data, threedgrut can be installable as a regular dependency, downstream projects can pull it in via `uv add` / `pip install`
