### PR TITLE
Add v1.1.0 package version metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v1.1.0 - 2026-06-10
+
+- Set the Python package metadata version to `1.1.0`.
+- Added runtime version access through `threedgrut.__version__`.
+- Moved package metadata into `pyproject.toml` and reduced `setup.py` to a setuptools compatibility shim.
+
+## v1.0.0 - 2025-04
+
+- Public stable release tag for 3DGRUT. Python package metadata was still pre-1.0 at that time and is aligned in v1.1.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "threedgrut"
-version = "0.0.2"
+version = "1.1.0"
 description = "Official implementation of 3DGRT and 3DGUT"
+authors = [
+    { name = "Nicolas Moenne-Loccoz, et al.", email = "nicolasm@nvidia.com" },
+]
 requires-python = ">=3.11"
+classifiers = [
+    "Operating System :: OS Independent",
+]
 
 dependencies = [
     "setuptools==78.1.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pygltflib
 # --find-links https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.1.2_cu118.html
 # kaolin==0.17.0
 usd-core>=26.3
-ppisp @ git+https://github.com/nv-tlabs/ppisp@41f3331b567ef366e4c261171007771f85f59e46
+ppisp @ git+https://github.com/nv-tlabs/ppisp@v1.2.1
 # NCore dataset support (https://github.com/NVIDIA/ncore)
 nvidia-ncore>=19.0.0
 simplejpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pygltflib
 # --find-links https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.1.2_cu118.html
 # kaolin==0.17.0
 usd-core>=26.3
-ppisp @ git+https://github.com/nv-tlabs/ppisp@v1.0.1
+ppisp @ git+https://github.com/nv-tlabs/ppisp@64d45972241a0ec5ac004b0ad255c9f721e3190c
 # NCore dataset support (https://github.com/NVIDIA/ncore)
 nvidia-ncore>=19.0.0
 simplejpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pygltflib
 # --find-links https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.1.2_cu118.html
 # kaolin==0.17.0
 usd-core>=26.3
-ppisp @ git+https://github.com/nv-tlabs/ppisp@64d45972241a0ec5ac004b0ad255c9f721e3190c
+ppisp @ git+https://github.com/nv-tlabs/ppisp@41f3331b567ef366e4c261171007771f85f59e46
 # NCore dataset support (https://github.com/NVIDIA/ncore)
 nvidia-ncore>=19.0.0
 simplejpeg

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,2 +1,2 @@
-ppisp @ git+https://github.com/nv-tlabs/ppisp@v1.0.1
+ppisp @ git+https://github.com/nv-tlabs/ppisp@64d45972241a0ec5ac004b0ad255c9f721e3190c
 fused-ssim @ git+https://github.com/rahul-goel/fused-ssim@1272e21a282342e89537159e4bad508b19b34157

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,2 +1,2 @@
-ppisp @ git+https://github.com/nv-tlabs/ppisp@64d45972241a0ec5ac004b0ad255c9f721e3190c
+ppisp @ git+https://github.com/nv-tlabs/ppisp@41f3331b567ef366e4c261171007771f85f59e46
 fused-ssim @ git+https://github.com/rahul-goel/fused-ssim@1272e21a282342e89537159e4bad508b19b34157

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,2 +1,2 @@
-ppisp @ git+https://github.com/nv-tlabs/ppisp@41f3331b567ef366e4c261171007771f85f59e46
+ppisp @ git+https://github.com/nv-tlabs/ppisp@v1.2.1
 fused-ssim @ git+https://github.com/rahul-goel/fused-ssim@1272e21a282342e89537159e4bad508b19b34157

--- a/setup.py
+++ b/setup.py
@@ -13,20 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
-VERSION = "0.0.1"
-
-setup(
-    name="threedgrut",
-    version=VERSION,
-    author="Nicolas Moenne-Loccoz, et al.",
-    author_email="nicolasm@nvidia.com",
-    description="Official implementation of 3DGRT and 3DGUT research projects.",
-    long_description_content_type="text/markdown",
-    py_modules=["threedgrut", "threedgrt_tracer", "threedgut_tracer", "playground"],
-    packages=find_packages(where="libs"),
-    python_requires=">=3.11",
-    install_requires=[],
-    classifiers=["Operating System :: OS Independent"],
-)
+setup()

--- a/threedgrut/__init__.py
+++ b/threedgrut/__init__.py
@@ -13,6 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tomllib
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
 from . import gui
 
-__all__ = ["gui"]
+UNKNOWN_VERSION = "0.0.0+unknown"
+
+
+def _read_version() -> str:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if pyproject_path.exists():
+        with pyproject_path.open("rb") as f:
+            return tomllib.load(f)["project"]["version"]
+
+    try:
+        return version("threedgrut")
+    except PackageNotFoundError:
+        return UNKNOWN_VERSION
+
+
+__version__ = _read_version()
+
+__all__ = ["gui", "__version__"]


### PR DESCRIPTION
 ## Summary

  Adds explicit Python package versioning for 3DGRUT and aligns package metadata around `pyproject.toml`.

  ## Changes

  - Set package version to `1.1.0`.
  - Expose runtime version access through `threedgrut.__version__`.
  - Move package author/classifier metadata into `pyproject.toml`.
  - Reduce `setup.py` to a minimal setuptools compatibility shim.
  - Add `CHANGELOG.md` with `v1.1.0` notes and context for the prior `v1.0.0` public release tag.

  ## Validation

  - `python setup.py --version`
  - `python -c "import threedgrut; print(threedgrut.__version__)"`
  - `python -m py_compile setup.py threedgrut/__init__.py`
  - `git diff --check`