### PR TITLE
Fix NHT GUI rendering and timings

### DIFF
--- a/threedgrut/utils/gui.py
+++ b/threedgrut/utils/gui.py
@@ -25,14 +25,19 @@ from threedgrut.datasets.protocols import Batch, DatasetVisualization
 from threedgrut.datasets.utils import DEFAULT_DEVICE, fov2focal
 from threedgrut.utils.logger import logger
 from threedgrut.utils.misc import to_np
+from threedgrut.utils.render import apply_feature_decoder
 from threedgrut.utils.timer import CudaTimer
 
 trajectory = []
 
 
 class GUI:
-    def __init__(self, conf, model, train_dataset, val_dataset, scene_bbox):
+    def __init__(self, conf, model, train_dataset, val_dataset, scene_bbox, feature_decoder=None):
         self.conf = conf
+        self.feature_decoder = feature_decoder
+        self.feature_decoder_center_ray_encoding = bool(
+            getattr(getattr(conf.model, "nht_decoder", None), "center_ray_encoding", False)
+        )
 
         self.update_from_device = self.conf.gui_update_from_device
         if not self.update_from_device:
@@ -199,6 +204,16 @@ class GUI:
 
             self.render_timer.start()
             outputs = self.model(inputs, train=self.viz_render_train_view)
+
+            # The model returns learned NHT features. Decode them here so the
+            # GUI always receives the same RGB output as the training loop.
+            outputs = apply_feature_decoder(
+                self.feature_decoder,
+                outputs,
+                inputs,
+                training=self.viz_render_train_view,
+                center_ray_encoding=self.feature_decoder_center_ray_encoding,
+            )
             self.render_timer.end()
             self.render_width = window_w
             self.render_height = window_h

--- a/threedgrut/utils/render.py
+++ b/threedgrut/utils/render.py
@@ -66,8 +66,10 @@ def apply_feature_decoder(
     alpha = outputs["pred_opacity"]  # [B, H, W] or [B, H, W, 1]
     B, H, W, N = feature_map.shape
 
-    R = gpu_batch.T_to_world[:, :3, :3]  # [B, 3, 3] c2w rotation
     rays_dir_cam = gpu_batch.rays_dir  # [B, H, W, 3]
+    # GUI camera batches keep poses on the CPU while rays/features are on the
+    # GPU. Match the pose device and ray dtype before computing world rays.
+    R = gpu_batch.T_to_world[:, :3, :3].to(device=rays_dir_cam.device, dtype=rays_dir_cam.dtype)  # [B, 3, 3]
     if center_ray_encoding:
         # center-ray mode uses the camera optical axis, i.e. row 2 of the
         # world-to-camera view matrix, which is equivalent to column 2 of

--- a/threedgrut/utils/viser_gui_util.py
+++ b/threedgrut/utils/viser_gui_util.py
@@ -23,16 +23,21 @@ import viser
 from threedgrut.datasets.protocols import Batch
 from threedgrut.datasets.utils import DEFAULT_DEVICE, fov2focal
 from threedgrut.utils.misc import to_np
+from threedgrut.utils.render import apply_feature_decoder
 from threedgrut.utils.timer import CudaTimer
 
 
 class ViserGUI:
-    def __init__(self, conf, model, train_dataset, val_dataset, scene_bbox):
+    def __init__(self, conf, model, train_dataset, val_dataset, scene_bbox, feature_decoder=None):
         self.conf = conf
         self.model = model
         self.train_dataset = train_dataset
         self.val_dataset = val_dataset
         self.scene_bbox = scene_bbox
+        self.feature_decoder = feature_decoder
+        self.feature_decoder_center_ray_encoding = bool(
+            getattr(getattr(conf.model, "nht_decoder", None), "center_ray_encoding", False)
+        )
 
         # Initialize Viser server
         self.server = viser.ViserServer(port=8080)
@@ -295,6 +300,16 @@ class ViserGUI:
         with torch.no_grad():
             self.render_timer.start()
             outputs = self.model(inputs, train=self.viz_render_train_view)
+
+            # The model returns learned NHT features. Decode them here so the
+            # GUI always receives the same RGB output as the training loop.
+            outputs = apply_feature_decoder(
+                self.feature_decoder,
+                outputs,
+                inputs,
+                training=self.viz_render_train_view,
+                center_ray_encoding=self.feature_decoder_center_ray_encoding,
+            )
             self.render_timer.end()
             self.render_width = window_w
             self.render_height = window_h


### PR DESCRIPTION
## Description

  Adds NHT feature-decoder support to both Polyscope and Viser GUIs.

  - Accepts feature_decoder in both GUI constructors.
  - Decodes NHT features to RGB before display.
  - Supports center_ray_encoding.
  - Handles CPU camera poses with GPU ray tensors.
  - Includes feature-decoder time in GUI render timings.

  ## Validation

  - Python compilation passed.
  - Decoder smoke test passed.
  - git diff --check passed.