### PR TITLE
fix(export): align NuRec radiance_sph_degree with imported SH degree

### DIFF
--- a/threedgrut/export/usd/nurec/exporter.py
+++ b/threedgrut/export/usd/nurec/exporter.py
@@ -469,7 +469,11 @@ class NuRecExporter(ModelExporter):
             "rotation_activation": "normalize",
             "density_kernel_density_clamping": conf.render.particle_kernel_density_clamping,
             "density_kernel_min_response": conf.render.particle_kernel_min_response,
-            "radiance_sph_degree": conf.render.particle_radiance_sph_degree,
+            # Match the radiance SH degree to the actual exported feature data
+            # (caps.sh_degree). Using the hardcoded config default (3) while the
+            # data carries a lower degree makes the NuRec shader read a mismatched
+            # specular buffer and renders black in Omniverse/Isaac Sim.
+            "radiance_sph_degree": caps.sh_degree,
             "transmittance_threshold": conf.render.min_transmittance,
         }
         if conf.render.method == "3dgut":


### PR DESCRIPTION
## Summary

Fixes NuRec USDZ exports from PLY transcoding rendering **black** in Omniverse / Isaac Sim when the input splat uses an SH degree lower than the hardcoded training-config default (typically 3).

## Problem

In `NuRecExporter._build_nurec_payload()`, the `.nurec` template already sets `n_active_features` from `caps.sh_degree` (inferred by the PLY importer from `f_rest_*` columns), but `radiance_sph_degree` was still taken from `conf.render.particle_radiance_sph_degree`.

For `transcode` from PLY there is no training config, so `_get_default_nurec_conf()` always supplies `particle_radiance_sph_degree=3`. A degree-1 PLY (9 `f_rest` coeffs) therefore exports with `n_active_features=1` and `radiance_sph_degree=3`. The NuRec shader reads a mismatched specular buffer and the viewport goes black.

## Solution

Set `radiance_sph_degree` to `caps.sh_degree`, matching `n_active_features` and the actual exported feature data.

## Testing

- Reproduced on Isaac Sim 5.1+ with `--/UJITSO/geometry=true`: degree-1 PLY → black before fix, renders after fix.
- Degree-3 PLY (`splatfacto-big` output): unchanged (both fields were already 3).

## Related

Similar root cause to #147 (open; targets the older `usdz_exporter.py` path). This change applies the same consistency fix to the current `NuRecExporter` used by `transcode`.
