### PR TITLE
Enable ruff and repair the repo-wide format gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install formatter dependencies
-        run: pip install black==26.3.1 isort==5.13.0
+        run: pip install black==26.3.1 isort==5.13.0 ruff==0.15.7 clang-format==18.1.8
 
       - name: Check code style
         run: bash scripts/formatter.sh --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
 dev = [
     "black==26.3.1",
     "isort==5.13.0",
+    "ruff==0.15.7",
     "clang-format==18.1.8",
 ]
 gui = [
@@ -118,6 +119,64 @@ url = "https://pypi.org/simple"
 # [[tool.uv.index]]
 # name = "pytorch"
 # url = "https://download.pytorch.org/whl"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+# Notebooks are left to their own tooling: black/isort do not process them either.
+extend-exclude = ["thirdparty", "*.ipynb"]
+
+[tool.ruff.lint]
+# Import sorting (I) is deliberately absent: isort already owns it.
+# pyupgrade (UP) is deliberately absent: PEP 585/604 modernisation is a separate,
+# repo-wide change, not a lint gate.
+select = ["E4", "E7", "E9", "F", "B", "SIM", "C4", "PERF", "RUF"]
+
+# Backlog: every rule below is violated by code that predates this config. They are
+# ignored so the gate is enforceable today, and are meant to be emptied one rule at a
+# time. Counts are as of the commit that introduced this list -- regenerate with
+# `ruff check --statistics .` after temporarily clearing an entry.
+ignore = [
+    # -- Correctness risk: fix these first --
+    "B023",    #  2  function-uses-loop-variable (closure captures the loop var)
+    "B026",    #  1  star-arg-unpacking-after-keyword-arg
+    "E722",    #  2  bare-except
+    "B011",    #  3  assert-false (vanishes under `python -O`)
+    "B904",    #  4  raise-without-from-inside-except (loses the original traceback)
+    "RUF013",  #  4  implicit-optional
+    "B905",    # 11  zip-without-explicit-strict
+    "RUF012",  # 12  mutable-class-default
+    "B008",    #  4  function-call-in-default-argument
+    "RUF018",  #  1  assignment-in-assert (vanishes under `python -O`)
+    "RUF028",  #  4  invalid-formatter-suppression-comment (fmt: off/on that does nothing)
+
+    # -- Dead code --
+    "F841",    # 11  unused-variable
+    "RUF059",  # 20  unused-unpacked-variable
+    "B007",    #  5  unused-loop-control-variable
+
+    # -- Style / readability --
+    "C408",    # 31  unnecessary-collection-call (dict() -> {})
+    "SIM108",  # 10  if-else-block-instead-of-if-exp
+    "PERF401", #  7  manual-list-comprehension
+    "RUF046",  #  6  unnecessary-cast-to-int
+    "E741",    #  5  ambiguous-variable-name
+    "SIM210",  #  4  if-expr-with-true-false
+    "E731",    #  3  lambda-assignment
+    "SIM102",  #  3  collapsible-if
+    "C404",    #  2  unnecessary-list-comprehension-dict
+    "C416",    #  2  unnecessary-comprehension
+    "E402",    #  2  module-import-not-at-top-of-file
+    "RUF005",  #  2  collection-literal-concatenation
+    "SIM103",  #  2  needless-bool
+    "SIM118",  #  2  in-dict-keys
+    "C414",    #  1  unnecessary-double-cast-or-process
+    "PERF102", #  1  incorrect-dict-iterator
+    "RUF001",  #  1  ambiguous-unicode-character-string
+    "RUF022",  #  1  unsorted-dunder-all
+    "RUF043",  #  1  pytest-raises-ambiguous-pattern
+    "SIM401",  #  1  if-else-block-instead-of-dict-get
+]
 
 [tool.black]
 target-version = ["py311"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,10 +173,14 @@ ignore = [
     "C414",    #  1  unnecessary-double-cast-or-process
     "PERF102", #  1  incorrect-dict-iterator
     "RUF001",  #  1  ambiguous-unicode-character-string
-    "RUF022",  #  1  unsorted-dunder-all
     "RUF043",  #  1  pytest-raises-ambiguous-pattern
     "SIM401",  #  1  if-else-block-instead-of-dict-get
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# This __all__ is grouped into commented sections mirroring the import order
+# above it; sorting reorders the entries out from under those comments.
+"threedgrut/export/__init__.py" = ["RUF022"]
 
 [tool.black]
 target-version = ["py311"]

--- a/scripts/formatter.sh
+++ b/scripts/formatter.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR=$(dirname "$0")
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 CHECK_MODE=false
 
 while [[ $# -gt 0 ]]; do
@@ -23,7 +23,7 @@ else
     ACTION="Formatting"
 fi
 
-pushd "$SCRIPT_DIR" &> /dev/null
+pushd "$REPO_ROOT" &> /dev/null
 
 CLANG_FORMAT_REQUIRED_VERSION=18
 if command -v clang-format &> /dev/null; then
@@ -47,7 +47,8 @@ if command -v clang-format &> /dev/null; then
     fi
     echo ""
 else
-    echo "clang-format not found. Install with: pip3 install clang-format"
+    echo "clang-format not found. Install with: pip3 install 'clang-format==18.*'"
+    FAILED=1
     echo ""
 fi
 
@@ -57,6 +58,14 @@ echo ""
 
 echo "$ACTION Python code with isort..."
 isort . ${ISORT_OPTS[@]+"${ISORT_OPTS[@]}"} --skip-gitignore --dont-follow-links --extend-skip=thirdparty/tiny-cuda-nn --profile=black || FAILED=1
+echo ""
+
+echo "$ACTION Python code with ruff..."
+if [ "$CHECK_MODE" = true ]; then
+    ruff check . || FAILED=1
+else
+    ruff check . --fix || FAILED=1
+fi
 echo ""
 
 popd &> /dev/null

--- a/threedgrut/__init__.py
+++ b/threedgrut/__init__.py
@@ -36,4 +36,4 @@ def _read_version() -> str:
 
 __version__ = _read_version()
 
-__all__ = ["gui", "__version__"]
+__all__ = ["__version__", "gui"]

--- a/threedgrut/datasets/datasetNcore.py
+++ b/threedgrut/datasets/datasetNcore.py
@@ -143,7 +143,7 @@ class NCoreDataset(torch.utils.data.Dataset, BoundedMultiViewDataset, DatasetVis
         with open(path, "r") as fp:
             try:
                 dataset_meta = json.load(fp)
-            except ValueError as e:
+            except ValueError:
                 raise ValueError(f"NCoreDataset: provided file {path} not a json file")
 
         assert all(
@@ -953,7 +953,7 @@ class NCoreDataset(torch.utils.data.Dataset, BoundedMultiViewDataset, DatasetVis
         sequence_point_clouds_source_ids = self.sequence_point_clouds_source_ids[self.sequence_id]
         assert len(
             sequence_point_clouds_source_ids
-        ), f"NCoreDataset: At least a single point cloud source needs to be available for point-cloud generation"
+        ), "NCoreDataset: At least a single point cloud source needs to be available for point-cloud generation"
         if point_clouds_source_ids is None:
             point_clouds_source_ids = [sequence_point_clouds_source_ids[0]]
 

--- a/threedgrut/export/__init__.py
+++ b/threedgrut/export/__init__.py
@@ -83,9 +83,9 @@ try:
     from threedgrut.export.transforms import estimate_normalizing_transform
 
     __all__ += [
-        "estimate_normalizing_transform",
         "compute_average_visibility",
         "compute_visibility_and_filter",
+        "estimate_normalizing_transform",
     ]
 except ModuleNotFoundError as e:
     # Only suppress when an optional dependency is absent: pxr (usd-core) for
@@ -104,8 +104,8 @@ try:
     from threedgrut.export.usd.nurec.exporter import NuRecExporter
 
     __all__ += [
-        "USDExporter",  # ParticleField3DGaussianSplat schema
         "NuRecExporter",  # Omniverse-compatible format
+        "USDExporter",  # ParticleField3DGaussianSplat schema
         "USDImporter",
     ]
 except ModuleNotFoundError as e:

--- a/threedgrut/export/adapter.py
+++ b/threedgrut/export/adapter.py
@@ -20,7 +20,6 @@ Provides an adapter that wraps GaussianAttributes as an ExportableModel,
 allowing existing exporters to work with imported data.
 """
 
-import numpy as np
 import torch
 
 from threedgrut.export.accessor import GaussianAttributes, ModelCapabilities

--- a/threedgrut/export/formats/ply.py
+++ b/threedgrut/export/formats/ply.py
@@ -17,7 +17,7 @@
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, List
+from typing import List
 
 import numpy as np
 import torch
@@ -26,9 +26,6 @@ from plyfile import PlyData, PlyElement
 from threedgrut.export.accessor import GaussianAttributes, GaussianExportAccessor
 from threedgrut.export.base import ExportableModel, ModelExporter
 from threedgrut.utils.logger import logger
-
-if TYPE_CHECKING:
-    from threedgrut.export.partition import PartitionResult
 
 
 class PLYExporter(ModelExporter):

--- a/threedgrut/export/importers/nurec_usd.py
+++ b/threedgrut/export/importers/nurec_usd.py
@@ -24,7 +24,7 @@ from typing import Optional, Tuple
 
 import msgpack
 import numpy as np
-from pxr import Gf, Sdf, Usd, UsdGeom
+from pxr import Gf, Usd, UsdGeom
 
 from threedgrut.export.accessor import GaussianAttributes, ModelCapabilities
 from threedgrut.export.importers.base import FormatImporter

--- a/threedgrut/export/partition.py
+++ b/threedgrut/export/partition.py
@@ -42,7 +42,11 @@ from typing import Dict, Iterator, Optional, Tuple
 import numpy as np
 import torch
 
-from threedgrut.export.accessor import GaussianAttributes, GaussianExportAccessor, ModelCapabilities
+from threedgrut.export.accessor import (
+    GaussianAttributes,
+    GaussianExportAccessor,
+    ModelCapabilities,
+)
 from threedgrut.export.base import ExportableModel
 from threedgrut.export.sh_rotation import rotate_specular
 from threedgrut.utils.misc import inverse_sigmoid, quaternion_to_so3
@@ -306,9 +310,7 @@ def split_large_gaussians(
         spec_b = post["specular"].index_select(0, b)
 
         post = {
-            "positions": torch.cat(
-                [post["positions"].index_select(0, keep), child0_pos, child1_pos], dim=0
-            ),
+            "positions": torch.cat([post["positions"].index_select(0, keep), child0_pos, child1_pos], dim=0),
             "scales": _cat_children("scales", child_scales),
             "rotations": _cat_children("rotations", child_quat),
             "densities": torch.cat([post["densities"].index_select(0, keep), dens_b, dens_b], dim=0),
@@ -542,7 +544,9 @@ def partition_scene(
         logger.info("Splitting oversized Gaussians (target footprint=%.4g, max_splits=%d)", target, max_splits)
         post, num_split_added = split_large_gaussians(post, target_size=target, n_sigma=n_sigma, max_splits=max_splits)
         if num_split_added:
-            logger.info("Split pass added %d Gaussians (%d -> %d)", num_split_added, num_gaussians, post["positions"].shape[0])
+            logger.info(
+                "Split pass added %d Gaussians (%d -> %d)", num_split_added, num_gaussians, post["positions"].shape[0]
+            )
         split_post = post
         positions = post["positions"]
         extents = gaussian_extents(post["scales"], post["rotations"], n_sigma=n_sigma)
@@ -558,9 +562,7 @@ def partition_scene(
     # axes. Grouping only — labels index the original Gaussians and the output is not reoriented.
     # The basis is opacity-weighted (visible mass drives the axes) and floater-trimmed.
     if normalized_frame:
-        weights = (
-            split_post["densities"] if split_post is not None else model.get_density(preactivation=False).detach()
-        )
+        weights = split_post["densities"] if split_post is not None else model.get_density(preactivation=False).detach()
         positions = _rotate_to_principal_axes(positions, weights)
 
     # Run the KD-tree on the GPU when the positions (+ sort workspace) fit the free memory
@@ -589,7 +591,6 @@ def partition_scene(
         _accessor=None if split_post is not None else accessor,
         _split_post=split_post,
     )
-
 
 
 def apply_frame_to_attributes(attrs: GaussianAttributes, transform, max_sh_degree: int) -> GaussianAttributes:

--- a/threedgrut/export/scripts/filter_visibility.py
+++ b/threedgrut/export/scripts/filter_visibility.py
@@ -28,7 +28,6 @@ Usage:
 """
 
 import logging
-from typing import Optional
 
 import numpy as np
 import torch

--- a/threedgrut/export/sh_rotation.py
+++ b/threedgrut/export/sh_rotation.py
@@ -32,7 +32,6 @@ this convention by construction (validated by held-out-direction equivariance in
 
 from typing import Dict
 
-import numpy as np
 import torch
 
 # Standard 3DGS real spherical-harmonics constants (match threedgrut/utils/render.py:C0..C2).

--- a/threedgrut/export/tests/test_ppisp_cuda_export.py
+++ b/threedgrut/export/tests/test_ppisp_cuda_export.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 
 import pytest
 import torch

--- a/threedgrut/export/tests/test_sh_rotation.py
+++ b/threedgrut/export/tests/test_sh_rotation.py
@@ -15,10 +15,14 @@
 
 """Tests for SH coefficient rotation (equivariance, round-trip transitivity, homomorphism)."""
 
-import numpy as np
 import torch
 
-from threedgrut.export.sh_rotation import band_rotation_matrices, eval_sh, num_sh_coefficients, rotate_specular
+from threedgrut.export.sh_rotation import (
+    band_rotation_matrices,
+    eval_sh,
+    num_sh_coefficients,
+    rotate_specular,
+)
 
 
 def _random_rotation(seed: int) -> torch.Tensor:

--- a/threedgrut/export/tests/test_transcode_roundtrip.py
+++ b/threedgrut/export/tests/test_transcode_roundtrip.py
@@ -35,7 +35,11 @@ from threedgrut.export.accessor import GaussianAttributes, ModelCapabilities
 from threedgrut.export.adapter import AttributesExportAdapter
 from threedgrut.export.formats import PLYExporter
 from threedgrut.export.importers import PLYImporter, USDImporter
-from threedgrut.export.scripts.transcode import detect_input_format, transcode, transcode_files
+from threedgrut.export.scripts.transcode import (
+    detect_input_format,
+    transcode,
+    transcode_files,
+)
 from threedgrut.export.transforms import usd_matrix_to_numpy
 from threedgrut.export.usd.exporter import USDExporter
 

--- a/threedgrut/export/usd/__init__.py
+++ b/threedgrut/export/usd/__init__.py
@@ -31,8 +31,8 @@ try:
     from threedgrut.export.usd.stage_utils import initialize_usd_stage
 
     __all__ += [
-        "USDExporter",
         "NuRecExporter",
+        "USDExporter",
         "initialize_usd_stage",
     ]
 except ModuleNotFoundError as e:

--- a/threedgrut/export/usd/camera_copy.py
+++ b/threedgrut/export/usd/camera_copy.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Collection, Iterator, List, Optional, Set, Tuple
 
-from pxr import Sdf, Usd, UsdGeom, UsdUtils
+from pxr import Sdf, Usd, UsdUtils
 
 from threedgrut.export.usd.stage_utils import NamedSerialized
 

--- a/threedgrut/export/usd/exporter.py
+++ b/threedgrut/export/usd/exporter.py
@@ -643,7 +643,7 @@ class USDExporter(ModelExporter):
             logger.info("Schema: LightField (post-activation), %d ParticleField partitions", total_partitions)
         else:
             attrs = accessor.get_attributes(preactivation=False)
-            logger.info(f"Schema: LightField (post-activation)")
+            logger.info("Schema: LightField (post-activation)")
             logger.info(f"Exporting {attrs.num_gaussians} Gaussians, SH degree {caps.sh_degree}")
 
         # Packaging decision (computed early so the size guard can fail fast before the write).
@@ -658,7 +658,9 @@ class USDExporter(ModelExporter):
         # largest partition instead of the combined total.
         if package_as_usdz:
             if use_separate_layers:
-                guard_count = max(int(r.metrics.get("count_max", r.metrics.get("total_exported", 0))) for r in partition_list)
+                guard_count = max(
+                    int(r.metrics.get("count_max", r.metrics.get("total_exported", 0))) for r in partition_list
+                )
                 guard_degree = max(
                     (r.capabilities.sh_degree for r in partition_list if r.capabilities is not None),
                     default=caps.sh_degree,
@@ -765,7 +767,9 @@ class USDExporter(ModelExporter):
                     _make_gaussian_root(part_stage)
                     part_root = f"{gaussians_root}/Partition_{running:0{width}d}"
                     _author_partition_prim(part_stage, part_root, src_t, sub, result_caps)
-                    partition_layers.append(NamedUSDStage(filename=f"gaussians_{running:0{width}d}.usdc", stage=part_stage))
+                    partition_layers.append(
+                        NamedUSDStage(filename=f"gaussians_{running:0{width}d}.usdc", stage=part_stage)
+                    )
                     running += 1
             logger.info("Authored %d ParticleField partition layer(s)", len(partition_layers))
         else:

--- a/threedgrut/export/usd/nurec/__init__.py
+++ b/threedgrut/export/usd/nurec/__init__.py
@@ -26,8 +26,8 @@ from threedgrut.export.usd.nurec.serializer import serialize_nurec_usd
 from threedgrut.export.usd.nurec.templates import NamedSerialized, fill_3dgut_template
 
 __all__ = [
-    "NuRecExporter",
     "NamedSerialized",
+    "NuRecExporter",
     "fill_3dgut_template",
     "serialize_nurec_usd",
 ]

--- a/threedgrut/export/usd/nurec/serializer.py
+++ b/threedgrut/export/usd/nurec/serializer.py
@@ -22,7 +22,7 @@ import zipfile
 from pathlib import Path
 
 import numpy as np
-from pxr import Gf, Sdf, Usd, UsdGeom, UsdUtils, UsdVol
+from pxr import Gf, Sdf, Usd, UsdUtils, UsdVol
 
 from threedgrut.export.transforms import (
     USDTransformSamples,

--- a/threedgrut/export/usd/nurec/templates.py
+++ b/threedgrut/export/usd/nurec/templates.py
@@ -19,8 +19,9 @@ from typing import Any, Dict
 
 import numpy as np
 
-# Import NamedSerialized from the canonical location
-from threedgrut.export.usd.stage_utils import NamedSerialized
+# Re-exported: serializer.py, exporter.py and nurec/__init__.py import NamedSerialized
+# from here, though stage_utils is the canonical definition.
+from threedgrut.export.usd.stage_utils import NamedSerialized  # noqa: F401
 
 
 def _fill_state_dict_tensors(

--- a/threedgrut/export/usd/writers/__init__.py
+++ b/threedgrut/export/usd/writers/__init__.py
@@ -32,10 +32,10 @@ from threedgrut.export.usd.writers.lightfield import GaussianLightFieldWriter
 from threedgrut.export.usd.writers.render_product import create_render_products
 
 __all__ = [
-    "GaussianUSDWriter",
     "GaussianLightFieldWriter",
+    "GaussianUSDWriter",
     "create_gaussian_writer",
-    "export_cameras_to_usd",
-    "export_background_to_usd",
     "create_render_products",
+    "export_background_to_usd",
+    "export_cameras_to_usd",
 ]

--- a/threedgrut/export/usd/writers/lightfield.py
+++ b/threedgrut/export/usd/writers/lightfield.py
@@ -24,7 +24,7 @@ import logging
 from typing import Optional
 
 import numpy as np
-from pxr import Gf, Sdf, Usd, UsdGeom, UsdVol, Vt
+from pxr import Gf, Usd, UsdGeom, UsdVol, Vt
 
 from threedgrut.export.accessor import GaussianAttributes, ModelCapabilities
 from threedgrut.export.usd.particle_field_hints import (
@@ -272,9 +272,7 @@ class GaussianLightFieldWriter(GaussianUSDWriter):
         num_gaussians = len(positions)
         if num_gaussians:
             mn, mx = positions.min(axis=0), positions.max(axis=0)
-            extent_str = (
-                f"min=[{mn[0]:.4g}, {mn[1]:.4g}, {mn[2]:.4g}] max=[{mx[0]:.4g}, {mx[1]:.4g}, {mx[2]:.4g}]"
-            )
+            extent_str = f"min=[{mn[0]:.4g}, {mn[1]:.4g}, {mn[2]:.4g}] max=[{mx[0]:.4g}, {mx[1]:.4g}, {mx[2]:.4g}]"
         else:
             extent_str = "empty"
         logger.info(f"  {self.prim.GetPath()}: {num_gaussians} gaussians, extent {extent_str}")

--- a/threedgrut/gui/ps_extension.py
+++ b/threedgrut/gui/ps_extension.py
@@ -54,11 +54,11 @@ def set_custom_cugl_bindings():
 
 def initialize_cugl_interop():
     try:
-        import polyscope
+        import polyscope  # noqa: F401  # availability probe
 
         try:
-            import cuda
-            import cupy
+            import cuda  # noqa: F401  # availability probe
+            import cupy  # noqa: F401  # availability probe
 
             logger.info("polyscope loaded with cupy, cuda-python for cu-opengl interop.")
             # polyscope is available with cupy / cuda-python, do nothing

--- a/threedgrut/gui/setup_gui.py
+++ b/threedgrut/gui/setup_gui.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-from pathlib import Path
 
 from threedgrut.utils import jit
 

--- a/threedgrut/model/feature_decoder.py
+++ b/threedgrut/model/feature_decoder.py
@@ -167,7 +167,7 @@ class FeatureDecoder(nn.Module):
                 W,
                 3,
             ), f"Ray directions shape mismatch: expected {(B, H, W, 3)}, got {ray_dirs_shape}"
-            assert N == self.ray_feature_dim, f"Expected {self.ray_feature_dim} features, got {N}"
+            assert self.ray_feature_dim == N, f"Expected {self.ray_feature_dim} features, got {N}"
 
             features_flat = features.reshape(B * H * W, N)
             ray_dirs_flat = ray_directions.reshape(B * H * W, 3)
@@ -179,7 +179,7 @@ class FeatureDecoder(nn.Module):
         elif len(features_shape) == 2:  # [H*W, N]
             HW, N = features_shape
             assert ray_dirs_shape == (HW, 3), f"Ray directions shape mismatch: expected {(HW, 3)}, got {ray_dirs_shape}"
-            assert N == self.ray_feature_dim, f"Expected {self.ray_feature_dim} features, got {N}"
+            assert self.ray_feature_dim == N, f"Expected {self.ray_feature_dim} features, got {N}"
             alpha_flat = alpha.reshape(HW, 1) if alpha is not None else None
             return self._process(features, ray_directions, alpha_flat)
         else:

--- a/threedgrut/model/model.py
+++ b/threedgrut/model/model.py
@@ -696,7 +696,7 @@ class MixtureOfGaussians(torch.nn.Module, ExportableModel):
         Observer points can be any set locations that observation came from.
         Camera centers, ray source points, etc. They are used to estimate initial scales.
         """
-        logger.info(f"Initializing based on lidar point cloud ...")
+        logger.info("Initializing based on lidar point cloud ...")
 
         self.default_initialize_from_points(
             point_cloud.xyz_end.to(device=self.device),
@@ -971,7 +971,7 @@ class MixtureOfGaussians(torch.nn.Module, ExportableModel):
             mogt_specular = mogt_specular.transpose(0, 2, 1).reshape((num_gaussians, num_speculars * 3))
         elif len(extra_f_names) == 0:
             # Only DC components available, create zero-filled higher-order harmonics
-            logger.info(f"PLY file only contains DC components, initializing higher-order spherical harmonics to zero")
+            logger.info("PLY file only contains DC components, initializing higher-order spherical harmonics to zero")
         else:
             # Partial data - this is unexpected
             raise ValueError(

--- a/threedgrut/render.py
+++ b/threedgrut/render.py
@@ -371,7 +371,7 @@ class Renderer:
             # Record the time
             inference_time.append(outputs["frame_time_ms"])
 
-            logger.log_progress(task_name="Rendering", advance=1, iteration=f"{str(iteration)}", psnr=psnr[-1])
+            logger.log_progress(task_name="Rendering", advance=1, iteration=f"{iteration!s}", psnr=psnr[-1])
 
         logger.end_progress(task_name="Rendering")
 

--- a/threedgrut/trainer.py
+++ b/threedgrut/trainer.py
@@ -644,16 +644,16 @@ class Trainer3DGRUT:
             metrics["hits_max"] = outputs["hits_count"].max().item()
 
         if is_compute_validation_metrics:
-            with torch.cuda.nvtx.range(f"criterions_psnr"):
+            with torch.cuda.nvtx.range("criterions_psnr"):
                 metrics["psnr"] = psnr(rgb_pred, rgb_gt).item()
 
             rgb_gt_full = rgb_gt.permute(0, 3, 1, 2)
             pred_features_full = rgb_pred.permute(0, 3, 1, 2)
             pred_features_full_clipped = rgb_pred.clip(0, 1).permute(0, 3, 1, 2)
 
-            with torch.cuda.nvtx.range(f"criterions_ssim"):
+            with torch.cuda.nvtx.range("criterions_ssim"):
                 metrics["ssim"] = ssim(pred_features_full, rgb_gt_full).item()
-            with torch.cuda.nvtx.range(f"criterions_lpips"):
+            with torch.cuda.nvtx.range("criterions_lpips"):
                 metrics["lpips"] = lpips(pred_features_full_clipped, rgb_gt_full).item()
 
             if iteration in self.conf.writer.log_image_views:
@@ -697,7 +697,7 @@ class Trainer3DGRUT:
         loss_l1 = torch.zeros(1, device=self.device)
         lambda_l1 = 0.0
         if self.conf.loss.use_l1:
-            with torch.cuda.nvtx.range(f"loss-l1"):
+            with torch.cuda.nvtx.range("loss-l1"):
                 loss_l1 = torch.abs(rgb_pred - rgb_gt).mean()
                 lambda_l1 = self.conf.loss.lambda_l1
 
@@ -705,7 +705,7 @@ class Trainer3DGRUT:
         loss_l2 = torch.zeros(1, device=self.device)
         lambda_l2 = 0.0
         if self.conf.loss.use_l2:
-            with torch.cuda.nvtx.range(f"loss-l2"):
+            with torch.cuda.nvtx.range("loss-l2"):
                 loss_l2 = torch.nn.functional.mse_loss(outputs["pred_features"], rgb_gt)
                 lambda_l2 = self.conf.loss.lambda_l2
 
@@ -713,7 +713,7 @@ class Trainer3DGRUT:
         loss_ssim = torch.zeros(1, device=self.device)
         lambda_ssim = 0.0
         if self.conf.loss.use_ssim:
-            with torch.cuda.nvtx.range(f"loss-ssim"):
+            with torch.cuda.nvtx.range("loss-ssim"):
                 rgb_gt_full = torch.permute(rgb_gt, (0, 3, 1, 2))
                 pred_features_full = torch.permute(rgb_pred, (0, 3, 1, 2))
                 loss_ssim = 1.0 - ssim(pred_features_full, rgb_gt_full)
@@ -723,7 +723,7 @@ class Trainer3DGRUT:
         loss_opacity = torch.zeros(1, device=self.device)
         lambda_opacity = 0.0
         if self.conf.loss.use_opacity and not self._in_color_refine:
-            with torch.cuda.nvtx.range(f"loss-opacity"):
+            with torch.cuda.nvtx.range("loss-opacity"):
                 loss_opacity = torch.abs(self.model.get_density()).mean()
                 lambda_opacity = self.conf.loss.lambda_opacity
 
@@ -731,7 +731,7 @@ class Trainer3DGRUT:
         loss_scale = torch.zeros(1, device=self.device)
         lambda_scale = 0.0
         if self.conf.loss.use_scale and not self._in_color_refine:
-            with torch.cuda.nvtx.range(f"loss-scale"):
+            with torch.cuda.nvtx.range("loss-scale"):
                 loss_scale = torch.abs(self.model.get_scale()).mean()
                 lambda_scale = self.conf.loss.lambda_scale
 
@@ -764,7 +764,7 @@ class Trainer3DGRUT:
         logger.log_progress(
             task_name="Validation",
             advance=1,
-            iteration=f"{str(iteration)}",
+            iteration=f"{iteration!s}",
             psnr=batch_metrics["psnr"],
             loss=batch_metrics["losses"]["total_loss"],
         )
@@ -847,7 +847,7 @@ class Trainer3DGRUT:
             table[time_key] = f"{'{:.2f}'.format(mean_timings[time_key])}" + " ms/it"
         logger.log_table(f"📊 Validation Metrics - Step {global_step}", record=table)
 
-    @torch.cuda.nvtx.range(f"log_training_iter")
+    @torch.cuda.nvtx.range("log_training_iter")
     def log_training_iter(
         self,
         gpu_batch: dict[str, torch.Tensor],
@@ -925,11 +925,11 @@ class Trainer3DGRUT:
         logger.log_progress(
             task_name="Training",
             advance=1,
-            step=f"{str(self.global_step)}",
+            step=f"{self.global_step!s}",
             loss=batch_metrics["losses"]["total_loss"],
         )
 
-    @torch.cuda.nvtx.range(f"log_training_pass")
+    @torch.cuda.nvtx.range("log_training_pass")
     def log_training_pass(self, metrics):
         """Log information after a single training pass.
         Args:
@@ -937,7 +937,7 @@ class Trainer3DGRUT:
         """
         pass
 
-    @torch.cuda.nvtx.range(f"on_training_end")
+    @torch.cuda.nvtx.range("on_training_end")
     def on_training_end(self):
         """Callback that prompts at the end of training."""
         conf = self.conf
@@ -1032,7 +1032,7 @@ class Trainer3DGRUT:
                 if self.feature_decoder is not None:
                     self.feature_decoder.restore_ema()
 
-    @torch.cuda.nvtx.range(f"save_checkpoint")
+    @torch.cuda.nvtx.range("save_checkpoint")
     def save_checkpoint(self, last_checkpoint: bool = False):
         """Saves checkpoint to a path under {conf.out_dir}/{conf.experiment_name}.
         Args:
@@ -1115,7 +1115,7 @@ class Trainer3DGRUT:
                 while not gui.viz_do_train:
                     time.sleep(0.0001)
 
-    @torch.cuda.nvtx.range(f"run_train_iter")
+    @torch.cuda.nvtx.range("run_train_iter")
     def run_train_iter(
         self,
         global_step: int,
@@ -1297,7 +1297,7 @@ class Trainer3DGRUT:
             elif self.conf.with_gui:
                 self.render_gui(scene_updated)
 
-    @torch.cuda.nvtx.range(f"run_train_pass")
+    @torch.cuda.nvtx.range("run_train_pass")
     def run_train_pass(self, conf: DictConfig):
         """Runs a single train epoch over the dataset."""
         metrics = []
@@ -1320,7 +1320,7 @@ class Trainer3DGRUT:
 
         self.log_training_pass(metrics)
 
-    @torch.cuda.nvtx.range(f"run_validation_pass")
+    @torch.cuda.nvtx.range("run_validation_pass")
     @torch.no_grad()
     def run_validation_pass(self, conf: DictConfig) -> dict[str, Any]:
         """Runs a single validation epoch over the dataset.
@@ -1427,14 +1427,14 @@ class Trainer3DGRUT:
             training_time=f"{stats['elapsed']:.2f} s",
             iteration_speed=f"{self.global_step / stats['elapsed']:.2f} it/s",
         )
-        logger.log_table(f"🎊 Training Statistics", record=table)
+        logger.log_table("🎊 Training Statistics", record=table)
 
         # Perform testing
         self.on_training_end()
-        logger.info(f"🥳 Training Complete.")
+        logger.info("🥳 Training Complete.")
 
         # Updating the GUI
         if self.gui is not None:
             self.gui.training_done = True
-            logger.info(f"🎨 GUI Blocking... Terminate GUI to Stop.")
+            logger.info("🎨 GUI Blocking... Terminate GUI to Stop.")
             self.gui.block_in_rendering_loop(fps=60)

--- a/threedgrut/utils/jit.py
+++ b/threedgrut/utils/jit.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import os
 import platform
 import sys

--- a/threedgrut/utils/logger.py
+++ b/threedgrut/utils/logger.py
@@ -78,7 +78,7 @@ class RichLogger:
 
     def log_table(self, title: str, record: dict):
         table = Table(title=title)
-        for key in record.keys():
+        for key in record:
             table.add_column(key, justify="left", style="yellow3", no_wrap=True)
         table.add_row(*[f"{'{:.3f}'.format(v)}" if isinstance(v, float) else v for v in record.values()])
         self.console.print(table)

--- a/threedgrut/utils/render.py
+++ b/threedgrut/utils/render.py
@@ -15,7 +15,6 @@
 
 
 import torch
-import torch.nn as nn
 
 ## NOTE: SPH code from gaussian-splatting, from plenoctree, from ???
 C0 = 0.28209479177387814

--- a/threedgrut_playground/engine.py
+++ b/threedgrut_playground/engine.py
@@ -30,16 +30,13 @@ from kaolin.render.camera import (
     generate_pinhole_rays,
 )
 
-from threedgrut.model.background import BackgroundColor
 from threedgrut.model.model import MixtureOfGaussians
-from threedgrut.utils.logger import logger
 from threedgrut_playground.tracer import Tracer
 from threedgrut_playground.utils.depth_of_field import DepthOfField
 from threedgrut_playground.utils.environment import Environment
 from threedgrut_playground.utils.kaolin_future.fisheye import generate_fisheye_rays
 from threedgrut_playground.utils.kaolin_future.transform import ObjectTransform
 from threedgrut_playground.utils.mesh_io import (
-    create_procedural_mesh,
     create_quad_mesh,
     load_materials,
     load_mesh,
@@ -915,7 +912,7 @@ class Engine3DGRUT:
             )
             rb["opacity"] = (rb["opacity"] * i + spp_rb["pred_opacity"]) / (i + self.spp.batch_size)
 
-    @torch.cuda.nvtx.range(f"playground._render_playground_hybrid")
+    @torch.cuda.nvtx.range("playground._render_playground_hybrid")
     def _render_playground_hybrid(self, rays_o: torch.Tensor, rays_d: torch.Tensor) -> Dict[str, torch.Tensor]:
         """Internal method for hybrid rendering of Gaussians and mesh primitives.
         Performs ray tracing through the scene, handling both 3D Gaussians and mesh

--- a/threedgrut_playground/ps_gui.py
+++ b/threedgrut_playground/ps_gui.py
@@ -660,7 +660,7 @@ class Playground:
             if self.engine.use_spp:
                 panel_width = psim.GetContentRegionAvail()[0]
                 progress_width = round(panel_width / 1.2)
-                progress_label = f"{str(self.engine.spp.spp_accumulated_for_frame)}/{str(self.engine.spp.spp)}"
+                progress_label = f"{self.engine.spp.spp_accumulated_for_frame!s}/{self.engine.spp.spp!s}"
                 psim.ProgressBar(
                     fraction=self.engine.spp.spp_accumulated_for_frame / self.engine.spp.spp,
                     size_arg=(progress_width, 0),
@@ -699,7 +699,7 @@ class Playground:
                 panel_width = psim.GetContentRegionAvail()[0]
                 progress_width = round(panel_width / 1.2)
                 progress_label = (
-                    f"{str(self.engine.depth_of_field.spp_accumulated_for_frame)}/{str(self.engine.depth_of_field.spp)}"
+                    f"{self.engine.depth_of_field.spp_accumulated_for_frame!s}/{self.engine.depth_of_field.spp!s}"
                 )
                 psim.ProgressBar(
                     fraction=self.engine.depth_of_field.spp_accumulated_for_frame / self.engine.depth_of_field.spp,
@@ -811,26 +811,26 @@ class Playground:
                     if material.diffuse_map is not None:
                         psim.Text(f"Diffuse Texture: {material.diffuse_map.shape[0]}x{material.diffuse_map.shape[1]}")
                     else:
-                        psim.Text(f"Diffuse Texture: No")
+                        psim.Text("Diffuse Texture: No")
 
                     if material.emissive_map is not None:
                         psim.Text(
                             f"Emissive Texture: {material.emissive_map.shape[0]}x{material.emissive_map.shape[1]}"
                         )
                     else:
-                        psim.Text(f"Emissive Texture: No")
+                        psim.Text("Emissive Texture: No")
 
                     if material.metallic_roughness_map is not None:
                         psim.Text(
                             f"Metal-Rough Texture: {material.metallic_roughness_map.shape[0]}x{material.metallic_roughness_map.shape[1]}"
                         )
                     else:
-                        psim.Text(f"Metal-Rough Texture: No")
+                        psim.Text("Metal-Rough Texture: No")
 
                     if material.normal_map is not None:
                         psim.Text(f"Normal Texture: {material.normal_map.shape[0]}x{material.normal_map.shape[1]}")
                     else:
-                        psim.Text(f"Normal Texture: No")
+                        psim.Text("Normal Texture: No")
 
                     psim.TreePop()
             psim.TreePop()

--- a/threedgrut_playground/utils/depth_of_field.py
+++ b/threedgrut_playground/utils/depth_of_field.py
@@ -32,7 +32,7 @@ class DepthOfField:
     """
 
     def __init__(self, spp=64, aperture_size=0.1, focus_z=1.0):
-        assert 0.0 <= aperture_size and 0.1 >= aperture_size
+        assert aperture_size >= 0.0 and aperture_size <= 0.1
         assert self.RNG_MODE in (
             "independent_random",
             "low_discrepancy_seq",

--- a/threedgrut_playground/utils/environment.py
+++ b/threedgrut_playground/utils/environment.py
@@ -107,10 +107,7 @@ class Environment:
         return self.envmap
 
     def set_env(self, env_name: Optional[str] = None) -> None:
-        if env_name == "Model-Background":
-            self._hdr_data = None
-            self.envmap = torch.zeros([512, 512, 4], dtype=torch.float32, device=self.device)
-        elif env_name == "Black":
+        if env_name == "Model-Background" or env_name == "Black":
             self._hdr_data = None
             self.envmap = torch.zeros([512, 512, 4], dtype=torch.float32, device=self.device)
         elif env_name == "White":

--- a/threedgrut_playground/utils/kaolin_future/interpolated_cameras.py
+++ b/threedgrut_playground/utils/kaolin_future/interpolated_cameras.py
@@ -28,10 +28,10 @@ As of March 26, 2025 the latest public release is kaolin 0.17.0, hence it's incl
 
 
 __all__ = [
+    "camera_path_generator",
+    "infinite_loop_camera_path_generator",
     "interpolate_camera_on_polynomial_path",
     "interpolate_camera_on_spline_path",
-    "infinite_loop_camera_path_generator",
-    "camera_path_generator",
 ]
 
 

--- a/threedgrut_playground/viser_gui.py
+++ b/threedgrut_playground/viser_gui.py
@@ -14,12 +14,10 @@ except ImportError:
 import argparse
 from collections import deque
 
-import cv2
-import kaolin
 from kaolin.render.camera import Camera
 
 from threedgrut.utils.misc import quaternion_to_so3
-from threedgrut_playground.engine import Engine3DGRUT, OptixPrimitiveTypes
+from threedgrut_playground.engine import Engine3DGRUT
 
 # Below code referenced from viser https://github.com/nerfstudio-project/viser
 # and viser 3dgs example: https://github.com/WangFeng18/3d-gaussian-splatting/blob/main/visergui.py

--- a/threedgut_tracer/tracer.py
+++ b/threedgut_tracer/tracer.py
@@ -36,7 +36,6 @@ _3dgut_plugin = None
 def load_3dgut_plugin(conf):
     global _3dgut_plugin
     if _3dgut_plugin is None:
-        import torch
 
         try:
             from . import lib3dgut_cc as tdgut  # type: ignore

--- a/tools/ppisp_export/bake_modes_benchmark/benchmark.py
+++ b/tools/ppisp_export/bake_modes_benchmark/benchmark.py
@@ -48,17 +48,15 @@ import torch.nn as nn
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from threedgrut.export.usd.post_processing_sh_bake import (  # noqa: E402
+from threedgrut.export.usd.post_processing_sh_bake import (
     MODE_PPISP_BAKE_VIGNETTING_NONE,
     FixedPPISP,
     PPISPPostProcessingBakeAdapter,
     bake_post_processing_into_sh,
 )
-from threedgrut.export.usd.post_processing_sh_simple_bake import (  # noqa: E402
-    simple_bake,
-)
-from threedgrut.render import Renderer  # noqa: E402
-from threedgrut.utils.render import apply_post_processing  # noqa: E402
+from threedgrut.export.usd.post_processing_sh_simple_bake import simple_bake
+from threedgrut.render import Renderer
+from threedgrut.utils.render import apply_post_processing
 
 logger = logging.getLogger("bake_modes_benchmark")
 

--- a/train.py
+++ b/train.py
@@ -19,7 +19,6 @@ import hydra
 from omegaconf import DictConfig, OmegaConf
 
 from threedgrut.utils.logger import logger
-from threedgrut.utils.timer import timing_options
 
 OmegaConf.register_new_resolver("int_list", lambda l: [int(x) for x in l])
 
@@ -38,7 +37,7 @@ def get_git_revision_hash() -> str:
 @hydra.main(config_path="configs", version_base=None)
 def main(conf: DictConfig) -> None:
     logger.info(f"Git hash: {get_git_revision_hash()}")
-    logger.info(f"Compiling native code..")
+    logger.info("Compiling native code..")
     from threedgrut.trainer import Trainer3DGRUT
 
     # # NOTE: It is also possible to directly instantiate a trainer from a checkpoint/INGP/PLY file

--- a/validate.py
+++ b/validate.py
@@ -21,7 +21,6 @@ Options
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 import time
@@ -177,7 +176,7 @@ def _write_report(rows: list[tuple], args, nht_ok: bool) -> str:
         f"Scene: `{args.data}`  \n",
         f"Iterations: {args.iterations}  \n",
         f"Particles: {args.particles:,}  \n",
-        f"Strategy: MCMC  \n",
+        "Strategy: MCMC  \n",
         f"NHT requested: {args.nht}  ",
         f"{'(supported)' if nht_ok else '(not available in this build — skipped)'}  \n\n",
         "## Results\n\n",
@@ -227,7 +226,7 @@ def main():
             rows.append((name, {}, 0.0))
             continue
 
-        print(f"\n[2/2] Evaluating ...")
+        print("\n[2/2] Evaluating ...")
         try:
             metrics = _render(name, ckpt, args)
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary

The CI format job has been checking **1 Python file instead of 140**. `scripts/formatter.sh` runs `pushd "$SCRIPT_DIR"`, so once the script moved into `scripts/` (2675ca0) every `black .`, `isort .` and `find .` below it operated on `scripts/` alone. `main` currently carries unformatted code with a green gate.

This PR repairs the gate, then adds ruff on top of it.

## What changed

**1. Format gate repair**

- `pushd` now targets the repo root. Coverage goes from 1 file to 140.
- The formatting that had accumulated behind the bug is applied (5 files, formatting only).
- The `clang-format` branch had a second hole: when the binary is absent the script echoed a hint and fell through *without setting `FAILED`*, and the CI job never installed it — so C/C++/CUDA formatting has never actually been checked. CI now installs `clang-format==18.1.8` and the missing-binary path fails. All 76 tracer/playground sources are already clean under 18.1.8, so this gate is green on arrival.

**2. Ruff enabled**

```toml
select = ["E4", "E7", "E9", "F", "B", "SIM", "C4", "PERF", "RUF"]
```

Two deliberate omissions, commented in `pyproject.toml`:
- `I` — isort already owns import sorting; two tools competing over it is worse than one.
- `UP` — its 477 hits are a repo-wide PEP 585/604 migration. That belongs in its own PR, not in a lint gate.

Notebooks are excluded to match black/isort, which do not process them either.

**3. Safe fixes applied — 78 of 252**

`F401` is fully clean and **stays enforced**. The only three survivors were availability probes in `gui/ps_extension.py` (`import polyscope` inside `try/except ImportError`); those got a targeted `# noqa: F401` rather than a repo-wide ignore.

**4. Exception list — 171 violations across 34 rules**

Annotated, grouped by priority, with per-rule counts and instructions for regenerating them:

```toml
# -- Correctness risk: fix these first --
"B023",    #  2  function-uses-loop-variable (closure captures the loop var)
"B026",    #  1  star-arg-unpacking-after-keyword-arg
"E722",    #  2  bare-except
"B011",    #  3  assert-false (vanishes under `python -O`)
"B904",    #  4  raise-without-from-inside-except
...
# -- Dead code --   F841 (11), RUF059 (20), B007 (5)
# -- Style --       C408 (31), SIM108 (10), ...
```

Meant to be emptied one rule at a time.

## Reviewer note: ruff broke a re-export, and only the tests caught it

`ruff --fix` deleted `from ...stage_utils import NamedSerialized` from `nurec/templates.py` as unused. It *is* unused in that file — but `serializer.py`, `exporter.py` and `nurec/__init__.py` all import the name **from templates**, so it was a re-export. Importing the export package died outright.

It is restored with a `# noqa: F401` naming its three consumers. All 60 removed imports were then audited for the same pattern; this was the only one.

Worth flagging what did *not* catch it: ruff's own `F821` stayed clean (the name is defined elsewhere), and so did `py_compile`. Only actually importing the package found it.

Two autofix follow-ups also needed a hand: dropping the only name from `ply.py`'s `TYPE_CHECKING` block left behind `if TYPE_CHECKING: pass` plus a now-unused import.

## Verification

```
bash scripts/formatter.sh --check        EXIT=0
  clang-format 18.1.8 ...... 76 files clean
  black .................... 140 files unchanged   (was 1)
  isort .................... clean
  ruff ..................... All checks passed!

pytest ................... 95 passed, 8 skipped
  test_export_import.py, test_ppisp_cuda_export.py, test_transcode_roundtrip.py  (the three CI files)
  test_partition.py, test_sh_rotation.py, test_geometry.py
```

## Out of scope, but noticed

`tools/ppisp_export/bake_modes_benchmark/benchmark.py` imports `threedgrut.export.usd.post_processing_sh_bake`, which no longer exists — it moved to `usd/post_processing/sh_bake.py` in d50b613. That file is already broken on `main`; ruff cannot see it because the imports *are* used within the file. Left alone here — happy to fix or delete it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
