### PR TITLE
Nicolasm/add surfel support to 3dgut

### DIFF
--- a/threedgrt_tracer/include/3dgrt/kernels/cuda/gaussianParticles.cuh
+++ b/threedgrt_tracer/include/3dgrt/kernels/cuda/gaussianParticles.cuh
@@ -367,6 +367,11 @@ __device__ inline bool processHit(
     const float3 rayDirR = rayDirection * particleRotation;
     const float3 grdu    = giscl * rayDirR;
     const float3 grd     = safe_normalize(grdu);
+    if constexpr (SurfelPrimitive) {
+        if (fabsf(grd.z) <= 1e-6f) {
+            return false;
+        }
+    }
 
     const float3 gcrod   = SurfelPrimitive ? gro + grd * -gro.z / grd.z : cross(grd, gro);
     const float grayDist = dot(gcrod, gcrod);
@@ -509,6 +514,11 @@ __device__ inline void processHitBwd(
     const float3 rayDirR = rayDirection * particleRotation;
     const float3 grdu    = giscl * rayDirR;
     const float3 grd     = safe_normalize(grdu);
+    if constexpr (SurfelPrimitive) {
+        if (fabsf(grd.z) <= 1e-6f) {
+            return;
+        }
+    }
     const float3 gcrod   = SurfelPrimitive ? gro + grd * -gro.z / grd.z : cross(grd, gro);
     const float grayDist = dot(gcrod, gcrod);
 

--- a/threedgrt_tracer/include/3dgrt/kernels/slang/models/gaussianParticles.slang
+++ b/threedgrt_tracer/include/3dgrt/kernels/slang/models/gaussianParticles.slang
@@ -177,20 +177,32 @@ struct Parameters : IDifferentiable {
     }
 }
 
-[BackwardDifferentiable][ForceInline] float canonicalRayDistance(
+[BackwardDifferentiable][ForceInline] float canonicalRayHitParameter<let Surfel : bool>(
+    float3 canonicalRayOrigin,
+    float3 canonicalRayDirection) {
+    if (Surfel) {
+        if (abs(canonicalRayDirection.z) <= 1e-6f) {
+            return 0.0f;
+        }
+        return -canonicalRayOrigin.z / canonicalRayDirection.z;
+    }
+    return dot(canonicalRayDirection, -1 * canonicalRayOrigin);
+}
+
+[BackwardDifferentiable][ForceInline] float canonicalRayDistance<let Surfel : bool>(
     float3 canonicalRayOrigin,
     float3 canonicalRayDirection,
     float3 scale) {
-    const float3 grds = scale * canonicalRayDirection * dot(canonicalRayDirection, -1 * canonicalRayOrigin);
+    const float3 grds = scale * canonicalRayDirection * canonicalRayHitParameter<Surfel>(canonicalRayOrigin, canonicalRayDirection);
     return sqrt(dot(grds, grds));
 }
 
-[BackwardDifferentiable] [ForceInline] float canonicalRayIntersection(
+[BackwardDifferentiable] [ForceInline] float canonicalRayIntersection<let Surfel : bool>(
     float3 canonicalRayOrigin,
     float3 canonicalRayDirection,
     float3 scale,
     out float3 canonicalIntersection) {
-    const float3 canonicalGrds = canonicalRayDirection * dot(canonicalRayDirection, -1 * canonicalRayOrigin);
+    const float3 canonicalGrds = canonicalRayDirection * canonicalRayHitParameter<Surfel>(canonicalRayOrigin, canonicalRayDirection);
     canonicalIntersection = canonicalRayOrigin + canonicalGrds;
     const float3 grds = scale * canonicalGrds;
     return sqrt(dot(grds, grds));
@@ -236,10 +248,11 @@ bool hit(
         canonicalRayDirection);
 
     alpha = min(MaxParticleAlpha, maxResponse * parameters.density); // needed for the stability of the backward pass
-    const bool acceptHit = ((maxResponse > MinParticleKernelDensity) && (alpha > MinParticleAlpha));
+    const bool acceptHit = (!Surfel || abs(canonicalRayDirection.z) > 1e-6f) &&
+                           (maxResponse > MinParticleKernelDensity) && (alpha > MinParticleAlpha);
     if (acceptHit)
     {
-        depth = canonicalRayIntersection(canonicalRayOrigin, canonicalRayDirection, parameters.scale, canonicalIntersection);
+        depth = canonicalRayIntersection<Surfel>(canonicalRayOrigin, canonicalRayDirection, parameters.scale, canonicalIntersection);
         if (enableNormal)
         {
             normal = canonicalRayNormal<Surfel>(canonicalRayOrigin, canonicalRayDirection, parameters.scale, parameters.rotationT);
@@ -512,10 +525,10 @@ bool particleDensityHitCustom(
         canonicalRayOrigin,
         canonicalRayDirection);
 
-    // distance to the gaussian center projection on the ray
-    hitDistance = gaussianParticle.canonicalRayDistance(canonicalRayOrigin, canonicalRayDirection, parameters.scale);
+    hitDistance = gaussianParticle.canonicalRayDistance<gaussianParticle.Surfel>(canonicalRayOrigin, canonicalRayDirection, parameters.scale);
 
-    return (hitDistance > minHitDistance) &&
+    return (!gaussianParticle.Surfel || abs(canonicalRayDirection.z) > 1e-6f) &&
+           (hitDistance > minHitDistance) &&
            (hitDistance < maxHitDistance) &&
            (gaussianParticle.canonicalRayMinSquaredDistance<gaussianParticle.Surfel>(
                 canonicalRayOrigin, canonicalRayDirection) < maxParticleSquaredDistance);
@@ -531,10 +544,18 @@ bool particleDensityHitInstance(
     out float hitDistance
 )
 {
-    const float numerator = -dot(canonicalRayOrigin, canonicalUnormalizedRayDirection);
-    const float denominator = rcp(dot(canonicalUnormalizedRayDirection, canonicalUnormalizedRayDirection));
-    hitDistance = numerator * denominator;
-    return (hitDistance > minHitDistance) &&
+    const bool validIntersection = !gaussianParticle.Surfel || abs(canonicalUnormalizedRayDirection.z) > 1e-6f;
+    if (gaussianParticle.Surfel) {
+        hitDistance = 0.0f;
+        if (validIntersection) {
+            hitDistance = -canonicalRayOrigin.z / canonicalUnormalizedRayDirection.z;
+        }
+    } else {
+        const float numerator = -dot(canonicalRayOrigin, canonicalUnormalizedRayDirection);
+        const float denominator = rcp(dot(canonicalUnormalizedRayDirection, canonicalUnormalizedRayDirection));
+        hitDistance = numerator * denominator;
+    }
+    return validIntersection && (hitDistance > minHitDistance) &&
            (hitDistance < maxHitDistance) &&
            (gaussianParticle.canonicalRayMinSquaredDistance<gaussianParticle.Surfel>(
                 canonicalRayOrigin,
@@ -559,4 +580,3 @@ bool particleDensityHitInstance(
     // 3DGRT: incidentDirectionFromBuffer returns no_diff; position gradient
     // from incident direction is not propagated back in the 3DGRT path.
 }
-

--- a/threedgrt_tracer/include/3dgrt/kernels/slang/models/neuralHarmonicFeaturesParticle.slang
+++ b/threedgrt_tracer/include/3dgrt/kernels/slang/models/neuralHarmonicFeaturesParticle.slang
@@ -17,7 +17,7 @@
 // Same CudaDeviceExport API as shRadiativeParticles.slang for drop-in replacement.
 // Compile-time: FEATURE_INTERPOLATION_TYPE, FEATURE_INTERPOLATION_SUPPORT, FEATURE_ACTIVATION_TYPE, FEATURE_ACTIVATION_NUM_FREQUENCIES,
 //   PARTICLE_FEATURE_DIM (total K per particle = buffer stride), INTERP_POINT_FEATURE_DIM (per-interpolation-point = K/num_points).
-// Support: center -> K=interpPointDim; tetrahedra -> K=4*interpPointDim.
+// Support: center -> K=interpPointDim; tetrahedra or two coplanar triangles -> K=4*interpPointDim.
 // With sincos activation: N = interpPointDim * num_frequencies * 2 (separate sin/cos channels).
 
 namespace neuralHarmonicFeaturesParticle
@@ -40,7 +40,7 @@ static const int InterpolationType = FEATURE_INTERPOLATION_TYPE;
 // Interpolation support (compile-time from FEATURE_INTERPOLATION_SUPPORT)
 static const int InterpolationSupport_Center = 0;
 static const int InterpolationSupport_Tetrahedra = 1;
-static const int InterpolationSupport_CoTriangles = 2; // 2 coplanar triangles / Not supported yet
+static const int InterpolationSupport_CoTriangles = 2; // 2 coplanar triangles
 static const int InterpolationSupport = FEATURE_INTERPOLATION_SUPPORT;
 
 // Canonical regular tetrahedron matching the GSplat NHT reference layout:
@@ -133,6 +133,22 @@ float4 barycentricTetrahedronCanonical(float3 P)
     return weights;
 }
 
+// The trisurfel is the union of triangles (0, 1, 2) and (0, 1, 3), with
+// canonical vertices (sqrt(2), 0), (-sqrt(2), 0), (0, sqrt(2)), and
+// (0, -sqrt(2)) in the local xy plane. The shared edge is y == 0.
+[BackwardDifferentiable][ForceInline]
+float3 barycentricTriSurfelCanonical(float3 P, out int thirdVertex)
+{
+    const float diagonal = 1.4142135623730951f;
+    const bool upperTriangle = P.y >= 0.0f;
+    const float signedY = upperTriangle ? P.y : -P.y;
+    const float wThird = signedY / diagonal;
+    const float w0 = 0.5f * (1.0f - wThird + P.x / diagonal);
+    const float w1 = 0.5f * (1.0f - wThird - P.x / diagonal);
+    thirdVertex = upperTriangle ? 2 : 3;
+    return float3(w0, w1, wThird);
+}
+
 // Encode and activate : none -> identity; siren -> sin(b*2^f); relu -> max(0,b).
 [BackwardDifferentiable][ForceInline]
 float encodeAndActivate(float baseVal, no_diff int f)
@@ -166,6 +182,18 @@ void featuresFromParametersBuffer(ParametersBuffer parametersBuffer,
             [ForceUnroll] for (int n = 0; n < InterpPointFeatureDim; ++n) {
                 baseFeatures[n] += barycentricWeights[k] * parameters.features[n];
             }
+        }
+    } else if (InterpolationSupport == InterpolationSupport_CoTriangles && InterpolationType == InterpolationType_Barycentric) {
+        int thirdVertex;
+        float3 barycentricWeights = barycentricTriSurfelCanonical(canonicalPosition, thirdVertex);
+        [ForceUnroll] for (int n = 0; n < InterpPointFeatureDim; ++n) {
+            baseFeatures[n] *= barycentricWeights[0];
+        }
+        Parameters secondParameters = fetchParametersFromBuffer(particleIdx, 1, parametersBuffer);
+        Parameters thirdParameters = fetchParametersFromBuffer(particleIdx, thirdVertex, parametersBuffer);
+        [ForceUnroll] for (int n = 0; n < InterpPointFeatureDim; ++n) {
+            baseFeatures[n] += barycentricWeights[1] * secondParameters.features[n];
+            baseFeatures[n] += barycentricWeights[2] * thirdParameters.features[n];
         }
     }
 

--- a/threedgrut/model/model.py
+++ b/threedgrut/model/model.py
@@ -193,12 +193,6 @@ class MixtureOfGaussians(torch.nn.Module, ExportableModel):
         # Feature type configuration - determine feature storage mode
         self.feature_type = Features.Type.from_string(self.conf.model.feature_type)
 
-        primitive_type = (getattr(conf.render, "primitive_type", None) or "").lower()
-        if self.feature_type == Features.Type.NHT and primitive_type == "trisurfel":
-            raise ValueError(
-                "Trisurfels are not supported in NHT mode. Use primitive_type 'instances' or 'icosahedron'."
-            )
-
         if self.feature_type == Features.Type.SH:
             # Spherical harmonics mode: separate albedo and specular features
             self.features_albedo = torch.nn.Parameter(

--- a/threedgut_tracer/include/3dgut/kernels/cuda/models/gaussianParticles.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/models/gaussianParticles.cuh
@@ -373,7 +373,9 @@ __device__ inline bool processHitFwd(
         particleScale,
         particleRotation,
         particleDensity);
-
+    if constexpr (SurfelPrimitive) {
+        particleScale.z = 1e-6f;
+    }
     const float3 giscl   = make_float3(1 / particleScale.x, 1 / particleScale.y, 1 / particleScale.z);
     const float3 gposc   = (rayOrigin - particlePosition);
     const float3 gposcr  = (gposc * particleRotation);
@@ -381,6 +383,11 @@ __device__ inline bool processHitFwd(
     const float3 rayDirR = rayDirection * particleRotation;
     const float3 grdu    = giscl * rayDirR;
     const float3 grd     = safe_normalize(grdu);
+    if constexpr (SurfelPrimitive) {
+        if (fabsf(grd.z) <= 1e-6f) {
+            return false;
+        }
+    }
 
     const float3 gcrod   = SurfelPrimitive ? gro + grd * -gro.z / grd.z : cross(grd, gro);
     const float grayDist = dot(gcrod, gcrod);
@@ -412,9 +419,14 @@ __device__ inline bool processHitFwd(
         *depth += hitT * weight;
 
         if (normal) {
-            constexpr float ellispoidSqRadius = 9.0f;
-            const float3 particleScaleRotated = (particleRotation * particleScale);
-            *normal += weight * (SurfelPrimitive ? make_float3(0, 0, (grd.z > 0 ? 1 : -1) * particleScaleRotated.z) : safe_normalize((gro + grd * (dot(grd, -1 * gro) - sqrtf(ellispoidSqRadius - grayDist))) * particleScaleRotated));
+            if constexpr (SurfelPrimitive) {
+                const float3 surfelNormal = safe_normalize(make_float3(0, 0, (grd.z > 0 ? 1 : -1)) * particleRotation);
+                *normal += weight * surfelNormal;
+            } else {
+                constexpr float ellispoidSqRadius = 9.0f;
+                const float3 particleScaleRotated = (particleRotation * particleScale);
+                *normal += weight * safe_normalize((gro + grd * (dot(grd, -1 * gro) - sqrtf(ellispoidSqRadius - grayDist))) * particleScaleRotated);
+            }
         }
     }
 
@@ -512,6 +524,9 @@ __device__ inline void processHitBwd(
     {
         particlePosition = particleData.position;
         gscl             = particleData.scale;
+        if constexpr (SurfelPrimitive) {
+            gscl.z = 1e-6f;
+        }
         grot             = particleData.quaternion;
         quaternionWXYZToMatrix(grot, particleRotation);
         particleDensity = particleData.density;
@@ -525,6 +540,11 @@ __device__ inline void processHitBwd(
     const float3 rayDirR = rayDirection * particleRotation;
     const float3 grdu    = giscl * rayDirR;
     const float3 grd     = safe_normalize(grdu);
+    if constexpr (SurfelPrimitive) {
+        if (fabsf(grd.z) <= 1e-6f) {
+            return;
+        }
+    }
     const float3 gcrod   = SurfelPrimitive ? gro + grd * -gro.z / grd.z : cross(grd, gro);
     const float grayDist = dot(gcrod, gcrod);
 
@@ -734,7 +754,13 @@ __device__ inline void processHitBwd(
         // ---> grdu = (1/gscl)*rayDirR
         // ===> d_grdu / d_gscl = -rayDirR/(gscl*gscl)
         // ===> d_grdu / d_rayDirR = (1/gscl)
-        particleDensityGradPtr->scale = gsclRayHitGrd + gsclGrdGro + (-rayDirR / (gscl * gscl)) * grduGrd;
+        float3 scaleGrd = gsclRayHitGrd + gsclGrdGro + (-rayDirR / (gscl * gscl)) * grduGrd;
+        if constexpr (SurfelPrimitive) {
+            // The canonical thickness is fixed above and does not depend on
+            // the stored third scale component.
+            scaleGrd.z = 0.0f;
+        }
+        particleDensityGradPtr->scale = scaleGrd;
         const float3 rayDirRGrd       = giscl * grduGrd;
 
         // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/threedgut_tracer/include/3dgut/kernels/cuda/models/shRadiativeGaussianParticles.cuh
+++ b/threedgut_tracer/include/3dgut/kernels/cuda/models/shRadiativeGaussianParticles.cuh
@@ -446,7 +446,7 @@ struct ShRadiativeGaussianVolumetricFeaturesParticles : Params, public ExtParams
                                                   float& transmittance,
                                                   TFeaturesVec& features,
                                                   float& hitT) const {
-        return threedgut::processHitFwd<ExtParams::KernelDegree, false, PerRayRadiance>(
+        return threedgut::processHitFwd<ExtParams::KernelDegree, GAUSSIAN_PARTICLE_SURFEL, PerRayRadiance>(
             reinterpret_cast<const float3&>(rayOrigin),
             reinterpret_cast<const float3&>(rayDirection),
             particleIdx,
@@ -480,7 +480,7 @@ struct ShRadiativeGaussianVolumetricFeaturesParticles : Params, public ExtParams
                                                   float hitTBackward,
                                                   float hitTGradient) const {
 
-        threedgut::processHitBwd<ExtParams::KernelDegree, false, PerRayRadiance>(
+        threedgut::processHitBwd<ExtParams::KernelDegree, GAUSSIAN_PARTICLE_SURFEL, PerRayRadiance>(
             reinterpret_cast<const float3&>(rayOrigin),
             reinterpret_cast<const float3&>(rayDirection),
             particleIdx,

--- a/threedgut_tracer/include/3dgut/kernels/slang/models/gaussianParticles.slang
+++ b/threedgut_tracer/include/3dgut/kernels/slang/models/gaussianParticles.slang
@@ -170,20 +170,32 @@ struct Parameters : IDifferentiable {
     }
 }
 
-[BackwardDifferentiable][ForceInline] float canonicalRayDistance(
+[BackwardDifferentiable][ForceInline] float canonicalRayHitParameter<let Surfel : bool>(
+    float3 canonicalRayOrigin,
+    float3 canonicalRayDirection) {
+    if (Surfel) {
+        if (abs(canonicalRayDirection.z) <= 1e-6f) {
+            return 0.0f;
+        }
+        return -canonicalRayOrigin.z / canonicalRayDirection.z;
+    }
+    return dot(canonicalRayDirection, -1 * canonicalRayOrigin);
+}
+
+[BackwardDifferentiable][ForceInline] float canonicalRayDistance<let Surfel : bool>(
     float3 canonicalRayOrigin,
     float3 canonicalRayDirection,
     float3 scale) {
-    const float3 grds = scale * canonicalRayDirection * dot(canonicalRayDirection, -1 * canonicalRayOrigin);
+    const float3 grds = scale * canonicalRayDirection * canonicalRayHitParameter<Surfel>(canonicalRayOrigin, canonicalRayDirection);
     return sqrt(dot(grds, grds));
 }
 
-[BackwardDifferentiable][ForceInline] float canonicalRayIntersection(
+[BackwardDifferentiable][ForceInline] float canonicalRayIntersection<let Surfel : bool>(
     float3 canonicalRayOrigin,
     float3 canonicalRayDirection,
     float3 scale,
     out float3 canonicalIntersection) {
-    const float3 canonicalGrds = canonicalRayDirection * dot(canonicalRayDirection, -1 * canonicalRayOrigin);
+    const float3 canonicalGrds = canonicalRayDirection * canonicalRayHitParameter<Surfel>(canonicalRayOrigin, canonicalRayDirection);
     canonicalIntersection = canonicalRayOrigin + canonicalGrds;
     const float3 grds = scale * canonicalGrds;
     return sqrt(dot(grds, grds));
@@ -201,7 +213,7 @@ struct Parameters : IDifferentiable {
     if (dot(surfelNm, canonicalRayDirection) > 0) {
         surfelNm *= -1.0f;
     }
-    return normalize(mul(surfelNm * scale, rotationT));
+    return normalize(mul(surfelNm, rotationT));
 }
 
 [BackwardDifferentiable][ForceInline]
@@ -229,10 +241,11 @@ bool hit(
         canonicalRayDirection);
 
     alpha = min(MaxParticleAlpha, maxResponse * parameters.density); // needed for the stability of the backward pass
-    const bool acceptHit = ((maxResponse > MinParticleKernelDensity) && (alpha > MinParticleAlpha));
+    const bool acceptHit = (!Surfel || abs(canonicalRayDirection.z) > 1e-6f) &&
+                           (maxResponse > MinParticleKernelDensity) && (alpha > MinParticleAlpha);
     if (acceptHit)
     {
-        depth = canonicalRayIntersection(canonicalRayOrigin, canonicalRayDirection, parameters.scale, canonicalIntersection);
+        depth = canonicalRayIntersection<Surfel>(canonicalRayOrigin, canonicalRayDirection, parameters.scale, canonicalIntersection);
         if (enableNormal)
         {
             normal = canonicalRayNormal<Surfel>(canonicalRayOrigin, canonicalRayDirection, parameters.scale, parameters.rotationT);
@@ -505,10 +518,10 @@ bool particleDensityHitCustom(
         canonicalRayOrigin,
         canonicalRayDirection);
 
-    // distance to the gaussian center projection on the ray
-    hitDistance = gaussianParticle.canonicalRayDistance(canonicalRayOrigin, canonicalRayDirection, parameters.scale);
+    hitDistance = gaussianParticle.canonicalRayDistance<gaussianParticle.Surfel>(canonicalRayOrigin, canonicalRayDirection, parameters.scale);
 
-    return (hitDistance > minHitDistance) &&
+    return (!gaussianParticle.Surfel || abs(canonicalRayDirection.z) > 1e-6f) &&
+           (hitDistance > minHitDistance) &&
            (hitDistance < maxHitDistance) &&
            (gaussianParticle.canonicalRayMinSquaredDistance<gaussianParticle.Surfel>(
                 canonicalRayOrigin, canonicalRayDirection) < maxParticleSquaredDistance);
@@ -524,10 +537,18 @@ bool particleDensityHitInstance(
     out float hitDistance
 )
 {
-    const float numerator = -dot(canonicalRayOrigin, canonicalUnormalizedRayDirection);
-    const float denominator = rcp(dot(canonicalUnormalizedRayDirection, canonicalUnormalizedRayDirection));
-    hitDistance = numerator * denominator;
-    return (hitDistance > minHitDistance) &&
+    const bool validIntersection = !gaussianParticle.Surfel || abs(canonicalUnormalizedRayDirection.z) > 1e-6f;
+    if (gaussianParticle.Surfel) {
+        hitDistance = 0.0f;
+        if (validIntersection) {
+            hitDistance = -canonicalRayOrigin.z / canonicalUnormalizedRayDirection.z;
+        }
+    } else {
+        const float numerator = -dot(canonicalRayOrigin, canonicalUnormalizedRayDirection);
+        const float denominator = rcp(dot(canonicalUnormalizedRayDirection, canonicalUnormalizedRayDirection));
+        hitDistance = numerator * denominator;
+    }
+    return validIntersection && (hitDistance > minHitDistance) &&
            (hitDistance < maxHitDistance) &&
            (gaussianParticle.canonicalRayMinSquaredDistance<gaussianParticle.Surfel>(
                 canonicalRayOrigin,

--- a/threedgut_tracer/include/3dgut/kernels/slang/models/neuralHarmonicFeaturesParticle.slang
+++ b/threedgut_tracer/include/3dgut/kernels/slang/models/neuralHarmonicFeaturesParticle.slang
@@ -17,7 +17,7 @@
 // Same CudaDeviceExport API as shRadiativeParticles.slang for drop-in replacement.
 // Compile-time: FEATURE_INTERPOLATION_TYPE, FEATURE_INTERPOLATION_SUPPORT, FEATURE_ACTIVATION_TYPE, FEATURE_ACTIVATION_NUM_FREQUENCIES,
 //   PARTICLE_FEATURE_DIM (total K per particle = buffer stride), INTERP_POINT_FEATURE_DIM (per-interpolation-point = K/num_points).
-// Support: center -> K=interpPointDim; tetrahedra -> K=4*interpPointDim.
+// Support: center -> K=interpPointDim; tetrahedra or two coplanar triangles -> K=4*interpPointDim.
 // With sincos activation: N = interpPointDim * num_frequencies * 2 (separate sin/cos channels).
 
 namespace neuralHarmonicFeaturesParticle
@@ -40,7 +40,7 @@ static const int InterpolationType = FEATURE_INTERPOLATION_TYPE;
 // Interpolation support (compile-time from FEATURE_INTERPOLATION_SUPPORT)
 static const int InterpolationSupport_Center = 0;
 static const int InterpolationSupport_Tetrahedra = 1;
-static const int InterpolationSupport_CoTriangles = 2; // 2 coplanar triangles / Not supported yet
+static const int InterpolationSupport_CoTriangles = 2; // 2 coplanar triangles
 static const int InterpolationSupport = FEATURE_INTERPOLATION_SUPPORT;
 
 // Canonical regular tetrahedron matching the GSplat NHT reference layout:
@@ -133,6 +133,22 @@ float4 barycentricTetrahedronCanonical(float3 P)
     return weights;
 }
 
+// The trisurfel is the union of triangles (0, 1, 2) and (0, 1, 3), with
+// canonical vertices (sqrt(2), 0), (-sqrt(2), 0), (0, sqrt(2)), and
+// (0, -sqrt(2)) in the local xy plane. The shared edge is y == 0.
+[BackwardDifferentiable][ForceInline]
+float3 barycentricTriSurfelCanonical(float3 P, out int thirdVertex)
+{
+    const float diagonal = 1.4142135623730951f;
+    const bool upperTriangle = P.y >= 0.0f;
+    const float signedY = upperTriangle ? P.y : -P.y;
+    const float wThird = signedY / diagonal;
+    const float w0 = 0.5f * (1.0f - wThird + P.x / diagonal);
+    const float w1 = 0.5f * (1.0f - wThird - P.x / diagonal);
+    thirdVertex = upperTriangle ? 2 : 3;
+    return float3(w0, w1, wThird);
+}
+
 // Encode and activate : none -> identity; siren -> sin(b*2^f); relu -> max(0,b).
 [BackwardDifferentiable][ForceInline]
 float encodeAndActivate(float baseVal, no_diff int f)
@@ -166,6 +182,18 @@ void featuresFromParametersBuffer(ParametersBuffer parametersBuffer,
             [ForceUnroll] for (int n = 0; n < InterpPointFeatureDim; ++n) {
                 baseFeatures[n] += barycentricWeights[k] * parameters.features[n];
             }
+        }
+    } else if (InterpolationSupport == InterpolationSupport_CoTriangles && InterpolationType == InterpolationType_Barycentric) {
+        int thirdVertex;
+        float3 barycentricWeights = barycentricTriSurfelCanonical(canonicalPosition, thirdVertex);
+        [ForceUnroll] for (int n = 0; n < InterpPointFeatureDim; ++n) {
+            baseFeatures[n] *= barycentricWeights[0];
+        }
+        Parameters secondParameters = fetchParametersFromBuffer(particleIdx, 1, parametersBuffer);
+        Parameters thirdParameters = fetchParametersFromBuffer(particleIdx, thirdVertex, parametersBuffer);
+        [ForceUnroll] for (int n = 0; n < InterpPointFeatureDim; ++n) {
+            baseFeatures[n] += barycentricWeights[1] * secondParameters.features[n];
+            baseFeatures[n] += barycentricWeights[2] * thirdParameters.features[n];
         }
     }
 

--- a/threedgut_tracer/include/3dgut/threedgut.slang
+++ b/threedgut_tracer/include/3dgut/threedgut.slang
@@ -20,7 +20,7 @@ namespace gaussianParticle
     static const float MaxParticleAlpha = GAUSSIAN_PARTICLE_MAX_ALPHA;
     static const float MinParticleAlpha = GAUSSIAN_PARTICLE_MIN_ALPHA;
     static const bool EnableNormal = false;
-    static const bool Surfel = false;
+    static const bool Surfel = GAUSSIAN_PARTICLE_SURFEL;
 };
 
 #include <3dgut/kernels/slang/models/gaussianParticles.slang>


### PR DESCRIPTION
# Add Trisurfel Support to 3DGUT and 3DGRT

  ## Summary

  This MR adds trisurfel support to both 3DGUT and 3DGRT, including Neural Harmonic Texture (NHT) support.

  ## Changes

  - Adds trisurfel rendering support to 3DGUT.
  - Ports and aligns trisurfel support with 3DGRT.
  - Computes surfel depth at the plane intersection.
  - Computes surfel normals in the local particle frame.
  - Masks the fixed surfel thickness gradient.
  - Adds NHT interpolation over the two coplanar trisurfel triangles.
  - Preserves the four-vertex feature layout for NHT.
  - Enables differentiated forward and backward NHT interpolation.
  - Removes the restriction preventing NHT with trisurfel primitives.

  ## Validation

  Validation was performed on the Nerf-360 room scene using 2× downsampling and 30,000 training steps on GPU 1.
  <table>
    <tr>
      <th>Renderer</th>
      <th>Features</th>
      <th>Primitive</th>
      <th>Steps</th>
      <th>Training time</th>
      <th>Speed</th>
      <th>PSNR</th>
      <th>SSIM</th>
      <th>LPIPS</th>
    </tr>
    <tr>
      <td>3DGRT</td>
      <td>SH</td>
      <td>Trisurfel</td>
      <td>30,000</td>
      <td>2240.02 s</td>
      <td>13.39 it/s</td>
      <td>30.475</td>
      <td>0.914</td>
      <td>0.296</td>
    </tr>
    <tr>
      <td>3DGUT</td>
      <td>SH</td>
      <td>Trisurfel</td>
      <td>30,000</td>
      <td>598.11 s</td>
      <td>50.16 it/s</td>
      <td>31.541</td>
      <td>0.917</td>
      <td>0.297</td>
    </tr>
    <tr>
      <td>3DGUT</td>
      <td>NHT</td>
      <td>Trisurfel</td>
      <td>30,000</td>
      <td>8036.20 s</td>
      <td>3.73 it/s</td>
      <td>33.325</td>
      <td>0.942</td>
      <td>0.237</td>
    </tr>
  </table>

  All three runs compiled successfully and completed training and evaluation.