### PR TITLE
bugfix: Replace indices with an array of ones to avoid zero.

### DIFF
--- a/threedgrut/datasets/dataset_colmap.py
+++ b/threedgrut/datasets/dataset_colmap.py
@@ -172,6 +172,9 @@ class ColmapDataset(Dataset, BoundedMultiViewDataset, DatasetVisualization):
                 indices = np.mod(indices, self.test_split_interval) != 0
             else:
                 indices = np.mod(indices, self.test_split_interval) == 0
+        else:
+            # Use all frames: convert to boolean mask (all True).
+            indices = np.ones(self.n_frames, dtype=bool)
 
         self.cam_extrinsics = [self.cam_extrinsics[i] for i in np.where(indices)[0]]
         self.poses = self.poses[indices].astype(np.float32)


### PR DESCRIPTION
This is necessary because np.where() below treats integer arrays as boolean conditions, where index 0 would be incorrectly treated as False. 